### PR TITLE
Added examples from Hansen et al.'s paper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,7 @@ all-ir: ${IR_TARGETS}
 
 clean:
 	rm -f klee-last *.o *.s *~ *.inputs core 
-	rm -rf ${TARGETS}
+	rm -rf ${TARGETS} ${HANSEN_TARGETS}
 
 # To prevent the removal of *.klee subdirectories
 .PRECIOUS: %.klee

--- a/Makefile
+++ b/Makefile
@@ -5,13 +5,39 @@
 # This Makefile will create klee output directories
 # <example-name>.klee which also contains the .dot files,
 # and also <example-name>.inputs that shows the input
-# values for each test.
+# values for each test. 
+#
+# Sample usages:
+#
+# To run all examples from the default targets:
+#
+# make
+#
+# To run a single example, e.g., number.c from the Hansen,
+# Schachte, and Sondergaard's article. These are currenly
+# separated from the default targets as they test the
+# performance limits of KLEE.
+#
+# make number.klee
+#
+# To build an LLVM language file of number.c:
+#
+# make number.s
+#
+# To clean the directory:
+#
+# make clean
 
 CC=llvm-gcc
 AS=llvm-gcc -S --emit-llvm
 CFLAGS=--emit-llvm -g
-TARGETS=addition.klee arraysimple2.klee even.klee polynomial.klee
 KLEE_FLAGS=-write-pcs -use-query-log=all:pc,all:smt2 -search=dfs
+
+# Default targets
+TARGETS=addition.klee arraysimple2.klee even.klee polynomial.klee simple.klee
+
+# Targets for examples from Hansen, Schachte, and Sondergaard
+HANSEN_TARGETS=number.klee wegner.klee multiply.klee
 
 #
 

--- a/multiply.c
+++ b/multiply.c
@@ -1,0 +1,40 @@
+/**
+ * Hansen, Schachte, Sondergaard: State Joining and Splitting for the
+ * Symbolic Execution of Binaries
+ *
+ * There are 2^64 paths through the function multiply. Simple enumeration
+ * without state merging would enumerate all paths.
+ */
+
+#include <stdint.h>
+
+#define even(x) ((x) & 1)
+
+uint64_t multiply(uint64_t x0, uint64_t y0);
+
+
+int main() {
+  uint64_t x0, y0;
+
+  klee_make_symbolic(&x0, sizeof(x0), "x0");
+  klee_make_symbolic(&y0, sizeof(y0), "y0");
+
+  return multiply(x0, y0);
+}
+
+uint64_t multiply(uint64_t x0, uint64_t y0) {
+  uint64_t x = x0, y = y0, z = 0;
+
+  klee_make_symbolic(&z, sizeof(z), "z");
+
+  while (x != 0) {
+    if (!even(x)) {
+      z += y;
+    }
+    x = x >> 1;
+    y = y << 1;
+  }
+
+  return z;
+}
+

--- a/number.c
+++ b/number.c
@@ -1,0 +1,29 @@
+/**
+ * Hansen, Schachte, Sondergaard: State Joining and Splitting for the
+ * Symbolic Execution of Binaries
+ *
+ * A somewhat classical example that shows the advantage of symbolic execution
+ * over black-box test generation. It is unlikely that a black-box random test
+ * approach would be able to figure out that failure is possible.
+ */
+
+#include <stdio.h>
+
+int main() {
+  char s[9];
+  long number;
+
+  printf("Enter a number:");
+  fgets(s, sizeof(s), stdin);
+  number = atol(s);
+
+  // We symbolicize the number at this point to
+  // make exploration possible.
+  klee_make_symbolic(&number, sizeof(number), "number");
+
+  if (number == 12345678) {
+    fail();
+  }
+
+  return 0;
+}

--- a/wegner.c
+++ b/wegner.c
@@ -1,0 +1,26 @@
+/**
+ * Hansen, Schachte, Sondergaard: State Joining and Splitting for the
+ * Symbolic Execution of Binaries
+ *
+ * This example counts the number of 1-bits in a symbolic 64-bit number.
+ * The example has 65 paths.
+ */
+
+#include <stdint.h>
+
+uint64_t popCount (uint64_t y);
+
+int main() {
+  uint64_t y;
+  klee_make_symbolic(&y, sizeof(y), "y");
+  return popCount(y);
+}
+
+uint64_t popCount (uint64_t y) {
+  uint64_t c;
+
+  for (c = 0; y; c++)
+    y &= y - 1;
+
+  return c;
+}


### PR DESCRIPTION
Added three simple examples from Hansen et al.'s paper: number.c, multiply.c and wegner.c. The examples test various aspects of path-enumeration-based symbolic execution. Please note that multiply.c currently segfaults when used with Z3.
