### PR TITLE
Added time reporting using time utility for KLEE runs

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -24,7 +24,7 @@ clean:
 .SUFFIXES: .klee .inputs
 
 .o.klee:
-	klee ${KLEE_FLAGS} -output-dir=$@ $<
+	time klee ${KLEE_FLAGS} -output-dir=$@ $<
 	opt -analyze -dot-cfg $<
 	mv *.dot $@
 


### PR DESCRIPTION
A small fix to execute 'time klee' instead of just 'klee' in Makefile.common.
