### PR TITLE
Made Basic Examples Use klee_assume

### DIFF
--- a/basic/Makefile
+++ b/basic/Makefile
@@ -13,7 +13,8 @@ TARGETS=addition.klee \
 	addition_safe4.klee \
 	addition_safe5.klee \
 	addition_safe6.klee \
-	addition_unsafe.klee \
+	addition_unsafe1.klee \
+	addition_unsafe2.klee \
 	sp.klee
 
 include ../Makefile.common

--- a/basic/addition.c
+++ b/basic/addition.c
@@ -19,17 +19,22 @@ ktest-tool --write-ints klee-last/test000003.ktest
 #include <assert.h>
 
 int add(int p1, int p2, int x) { 
-if(x <= 0){
+  klee_assume(x <= 0);
 
-	 if(p1 > 8) x = x; 
-		 else {x = x + 1;}
-         if(p2 > 8) x = x;
-	 	else {x = x + 2;}
+  if (p1 > 8)
+    x = x; 
+  else
+    x = x + 1;
+  if (p2 > 8)
+    x = x;
+  else
+    x = x + 2;
+  
+  assert(x <= 3);
 
-	 assert(x <= 3);
- }
- return x;
+  return x;
 } 
+
 int main() {
   int p1,p2, x;
   klee_make_symbolic(&p1, sizeof(p1), "p1");

--- a/basic/addition_safe1.c
+++ b/basic/addition_safe1.c
@@ -17,22 +17,21 @@ ktest-tool --write-ints klee-last/test000003.ktest
 int y;
 
 int add(int p1, int p2, int p3, int x) {
-  if (x <= 0) {
-    if (p1 > 8)
-      x = x + 1;
-    if (p2 > 8)
-      x = x;
-    else {
-      x = x + 2;
-    }
-    if (p3 > 8) {
-      x = x + 3;
-    }
+  klee_assume(x <= 0);
 
-    assert(x <= 6);
-  }
+  if (p1 > 8)
+    x = x + 1;
+  if (p2 > 8)
+    x = x;
+  else
+    x = x + 2;
+  if (p3 > 8)
+    x = x + 3;
+
+  assert(x <= 6);
   return x;
 }
+
 int main() {
   int p1, p2, p3;
   klee_make_symbolic(&p1, sizeof(p1), "p1");

--- a/basic/addition_safe2.c
+++ b/basic/addition_safe2.c
@@ -1,23 +1,21 @@
 /*
-  Copyright 2015 National University of Singapore
-
-  This example shows how subsumption work, even without
-  the handling of existentially-quantified formulas. The
-  formula to be proved valid in subsumption checks for
-  this example does not require quantification.
-
-cd
-cd nus/kleetest
-llvm-gcc --emit-llvm -c -g addition_safe2.c
-llvm-gcc -S --emit-llvm addition_safe2.c
-opt -analyze -dot-cfg addition_safe2.o
-klee -write-pcs -use-query-log=all:pc,all:smt2 -search=dfs addition_safe2.o
-ktest-tool --write-ints klee-last/test000001.ktest
-ktest-tool --write-ints klee-last/test000002.ktest
-ktest-tool --write-ints klee-last/test000003.ktest
-
-
-*/
+ * Copyright 2015 National University of Singapore
+ *
+ * This example demonstrates the ability of the system to
+ * compute the dependent memory regions (cells that
+ * influence the unsatisfiability core) as part of the
+ * interpolant.
+ *
+ * cd
+ * cd nus/kleetest
+ * llvm-gcc --emit-llvm -c -g addition_safe2.c
+ * llvm-gcc -S --emit-llvm addition_safe2.c
+ * opt -analyze -dot-cfg addition_safe2.o
+ * klee -write-pcs -use-query-log=all:pc,all:smt2 -search=dfs addition_safe2.o
+ * ktest-tool --write-ints klee-last/test000001.ktest
+ * ktest-tool --write-ints klee-last/test000002.ktest
+ * ktest-tool --write-ints klee-last/test000003.ktest
+ */
 #include <klee/klee.h>
 #include <assert.h>
 

--- a/basic/addition_safe2.c
+++ b/basic/addition_safe2.c
@@ -22,26 +22,27 @@
 int y;
 
 int add(int p1, int p2, int p3, int x) {
-  if (x <= 0) {
-    if (p1 > 8)
-      x = x + 1;
-    else
-      x = 1;
-    if (p2 > 8)
-      x = x + 2;
-    else {
-      x = 0;
-    }
-    if (p3 > 8)
-      x = x + 3;
-    else {
-      x = 3;
-    }
 
-    assert(x <= 6);
-  }
+  klee_assume(x <= 0);
+
+  if (p1 > 8)
+    x = x + 1;
+  else
+    x = 1;
+  if (p2 > 8)
+    x = x + 2;
+  else
+    x = 0;
+
+  if (p3 > 8)
+    x = x + 3;
+  else
+    x = 3;
+ 
+  assert(x <= 6);
   return x;
 }
+
 int main() {
   int p1, p2, p3;
   klee_make_symbolic(&p1, sizeof(p1), "p1");

--- a/basic/addition_safe3.c
+++ b/basic/addition_safe3.c
@@ -20,17 +20,17 @@ ktest-tool --write-ints klee-last/test000003.ktest
 int y;
 
 int add(int p1, int x) {
-  if (x <= 0) {
-    if (p1 > 8)
-      x = x;
-    else {
-      x = x + 2;
-    }
+  klee_assume(x <= 0);
 
-    assert(x <= 6);
-  }
+  if (p1 > 8)
+    x = x;
+  else
+      x = x + 2;
+
+  assert(x <= 6);
   return x;
 }
+
 int main() {
   int p1;
   klee_make_symbolic(&p1, sizeof(p1), "p1");

--- a/basic/addition_safe4.c
+++ b/basic/addition_safe4.c
@@ -23,20 +23,19 @@ int y;
  */
 int add(int p1, int p2, int p3, int x) {
   int z = 6;
-  if (x <= 0) {
-    if (p1 > 8)
-      x = x + 1;
-    if (p2 > 8)
-      x = x;
-    else {
-      x = x + 2;
-    }
-    if (p3 > 8) {
-      x = x + 3;
-    }
 
-    assert(x <= z);
-  }
+  klee_assume(x <= 0);
+  
+  if (p1 > 8)
+    x = x + 1;
+  if (p2 > 8)
+    x = x;
+  else
+    x = x + 2;
+  if (p3 > 8)
+    x = x + 3;
+
+  assert(x <= z);
   return x;
 }
 

--- a/basic/addition_safe5.c
+++ b/basic/addition_safe5.c
@@ -1,47 +1,48 @@
 /*
-Copyright 2016 National University of Singapore
-
-This is an example where Z3 would be strong enough
-to solve some of the quantified formulas obtaining
-some subsumptions, in Tracer-X revision 48a1345.
-
-cd
-cd nus/kleetest
-llvm-gcc --emit-llvm -c -g addition_safe5.c
-llvm-gcc -S --emit-llvm addition_safe5.c
-opt -analyze -dot-cfg addition_safe5.o
-klee -write-pcs -use-query-log=all:pc,all:smt2 -search=dfs addition_safe5.o
-ktest-tool --write-ints klee-last/test000001.ktest
-ktest-tool --write-ints klee-last/test000002.ktest
-ktest-tool --write-ints klee-last/test000003.ktest
-
-*/
+ * Copyright 2016 National University of Singapore
+ *
+ * This is an example where Z3 would be strong enough
+ * to solve some of the quantified formulas obtaining
+ * some subsumptions, in Tracer-X revision 48a1345.
+ *
+ * cd
+ * cd nus/kleetest
+ * llvm-gcc --emit-llvm -c -g addition_safe5.c
+ * llvm-gcc -S --emit-llvm addition_safe5.c
+ * opt -analyze -dot-cfg addition_safe5.o
+ * klee -write-pcs -use-query-log=all:pc,all:smt2 -search=dfs addition_safe5.o
+ * ktest-tool --write-ints klee-last/test000001.ktest
+ * ktest-tool --write-ints klee-last/test000002.ktest
+ * ktest-tool --write-ints klee-last/test000003.ktest
+ */
 #include <klee/klee.h>
 #include <assert.h>
 
 int y;
 
 int add(int p1, int p2, int p3, int x) {
-  if (x <= 0) {
-    if (p1 > 8)
-      x = x + 1;
-    else
-      x = x + 2;
-    if (p2 > 8)
-      x = x + 1;
-    else {
-      x = x + 2;
-    }
-    if (p3 > 8) {
-      x = x + 1;
-    } else {
-      x = x + 2;
-    }
+  klee_assume(x <= 0);
 
-    assert(x <= 6);
-  }
+  if (p1 > 8)
+    x = x + 1;
+  else
+    x = x + 2;
+
+  if (p2 > 8)
+    x = x + 1;
+  else
+    x = x + 2;
+
+  if (p3 > 8)
+    x = x + 1;
+  else
+    x = x + 2;
+
+  assert(x <= 6);
+
   return x;
 }
+
 int main() {
   int p1, p2, p3;
   klee_make_symbolic(&p1, sizeof(p1), "p1");

--- a/basic/addition_safe6.c
+++ b/basic/addition_safe6.c
@@ -18,22 +18,22 @@ int main() {
   klee_make_symbolic(&p3, sizeof(p3), "p3");
   klee_make_symbolic(&x, sizeof(x), "x");
 
-  if (x <= 0) {
-    if (p1 > 8)
-      x = x + 1;
-    else
-      x = x + 2;
-    if (p2 > 8)
-      x = x + 1;
-    else
-      x = x + 2;
-    if (p3 > 8)
-      x = x + 1;
-    else
-      x = x + 2;
+  klee_assume (x <= 0);
 
-    assert(x <= 6);
-  }
+  if (p1 > 8)
+    x = x + 1;
+  else
+    x = x + 2;
+  if (p2 > 8)
+    x = x + 1;
+  else
+    x = x + 2;
+  if (p3 > 8)
+    x = x + 1;
+  else
+    x = x + 2;
+  
+  assert(x <= 6);
 
   return 0;
 }

--- a/basic/addition_unsafe1.c
+++ b/basic/addition_unsafe1.c
@@ -18,16 +18,19 @@ ktest-tool --write-ints klee-last/test000003.ktest
 #include <assert.h>
 
 int add(int p1, int p2, int p3, int x) { 
-if(x <= 0){
-	 if(p1 > 8) x = x + 1; 
-	 if(p2 > 8) x = x;
-	 	else {x = x + 2;}
-	 if(p3 > 8) {x = x + 3;}
-	  
-	 assert(x <= 5);
- }
- return x;
+  klee_assume (x <= 0);
+  if (p1 > 8)
+    x = x + 1; 
+  if (p2 > 8)
+    x = x;
+  else
+    x = x + 2;
+  if (p3 > 8)
+    x = x + 3;
+  assert(x <= 5);
+  return x;
 } 
+
 int main() {
   int p1,p2, p3, x;
   klee_make_symbolic(&p1, sizeof(p1), "p1");

--- a/basic/sp.c
+++ b/basic/sp.c
@@ -17,25 +17,24 @@ int y;
 void proc(int x, int y) {
   int z = 5;
 
-  // The first conditional is to prevent underflow
-  if (x >= -1 && y >= -1) {
+  // This assume is to prevent underflow
+  klee_assume (x >= -1 && y >= -1);
 
-    if (x > 0) {
-      x = 2;
-    } else {
-      x += 2;
-    }
-
-    if (y > 0) {
-      y = 2;
-      x++;
-    } else {
-      y += 2;
-      x++;
-    }
-
-    assert(x + y <= z);
+  if (x > 0) {
+    x = 2;
+  } else {
+    x += 2;
   }
+
+  if (y > 0) {
+    y = 2;
+    x++;
+  } else {
+    y += 2;
+    x++;
+  }
+
+  assert(x + y <= z);
 }
 
 int main() {


### PR DESCRIPTION
I've made `basic` examples use `klee_assume` whenever they should, as we can now handle `klee_assume`, thanks to @feliciahalim 's work.
