### PR TITLE
Fixed klee_assume in sp.c to only use atomic conditions

### DIFF
--- a/basic/sp.c
+++ b/basic/sp.c
@@ -1,14 +1,14 @@
 /*
-Copyright 2015 National University of Singapore 
-cd
-cd nus/kleetest
-llvm-gcc --emit-llvm -c -g sp.c
-llvm-gcc -S --emit-llvm sp.c
-opt -analyze -dot-cfg sp.o
-klee -write-pcs -use-query-log=all:pc,all:smt2 -search=dfs sp.o
-ktest-tool --write-ints klee-last/test00000?.ktest
-
-*/
+ * Copyright 2015 National University of Singapore 
+ *
+ * cd
+ * cd nus/kleetest
+ * llvm-gcc --emit-llvm -c -g sp.c
+ * llvm-gcc -S --emit-llvm sp.c
+ * opt -analyze -dot-cfg sp.o
+ * klee -write-pcs -use-query-log=all:pc,all:smt2 -search=dfs sp.o
+ * ktest-tool --write-ints klee-last/test00000?.ktest
+ */
 #include <klee/klee.h>
 #include <assert.h>
 

--- a/basic/sp.c
+++ b/basic/sp.c
@@ -12,13 +12,12 @@ ktest-tool --write-ints klee-last/test00000?.ktest
 #include <klee/klee.h>
 #include <assert.h>
 
-int y;
-
 void proc(int x, int y) {
   int z = 5;
 
-  // This assume is to prevent underflow
-  klee_assume (x >= -1 && y >= -1);
+  // These assumes are to prevent underflow
+  klee_assume (x >= -1);
+  klee_assume (y >= -1);
 
   if (x > 0) {
     x = 2;


### PR DESCRIPTION
This is because KLEE is unable to handle composite conditions in `klee_assume`, e.g., `klee_assume(cond1 && cond2)`.
