### PR TITLE
Made KLEE and CFLAGS variables in Makefile.common be paella default

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -2,13 +2,18 @@
 #
 # Copyright 2015 National University of Singapore
 
-CC=clang
+
+# In the following, please select where klee is located in your system
 KLEE=klee
 #KLEE=${HOME}/git/memdepend/klee/Release+Asserts/bin/klee
-AS=${CC} -S -emit-llvm
+
+# In the following, please select suitable include directory
 CFLAGS=-emit-llvm -g -I/usr/local/lib/tracerx/include
 #CFLAGS=-emit-llvm -g -I${HOME}/nus/kleetest
 #CFLAGS=-emit-llvm -g -I${HOME}/software/klee/include
+
+CC=clang
+AS=${CC} -S -emit-llvm
 KLEE_FLAGS=${EXTRA_OPTIONS} -search=dfs
 
 INPUT_TARGETS=$(subst .klee,.inputs,${TARGETS})

--- a/Makefile.common
+++ b/Makefile.common
@@ -3,10 +3,11 @@
 # Copyright 2015 National University of Singapore
 
 CC=clang
-KLEE=${HOME}/git/memdepend/klee/Release+Asserts/bin/klee
-#KLEE=klee
+KLEE=klee
+#KLEE=${HOME}/git/memdepend/klee/Release+Asserts/bin/klee
 AS=${CC} -S -emit-llvm
-CFLAGS=-emit-llvm -g -I${HOME}/nus/kleetest
+CFLAGS=-emit-llvm -g -I/usr/local/lib/tracerx/include
+#CFLAGS=-emit-llvm -g -I${HOME}/nus/kleetest
 #CFLAGS=-emit-llvm -g -I${HOME}/software/klee/include
 KLEE_FLAGS=${EXTRA_OPTIONS} -search=dfs
 


### PR DESCRIPTION
Users should edit `Makefile.common` to set the correct values for KLEE and CFLAGS before they can run `make`, unless when they run it on paella server.
