### PR TITLE
Added Examples to Test Handling of Symbolic Addresses

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 Simple examples for running with KLEE
 
-Copyright 2015 National University of Singapore
+Copyright 2015, 2016 National University of Singapore
 
 To run the examples using KLEE, first edit Makefile.common to set the
 right variable values for your system.

--- a/basic/arraysimple4.c
+++ b/basic/arraysimple4.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2016 National University of Singapore
+ *
+ * This example triggered an assertion failure in Tracer-X KLEE's
+ * Z3Builder::constructActual.
+ */
+#include <klee/klee.h>
+#include <assert.h>
+
+int main() {
+  unsigned char a[4] = "abc";
+  unsigned i;
+  int p1, p2;
+
+  klee_make_symbolic(&i, sizeof(i), "i");
+  klee_make_symbolic(&p1, sizeof(p1), "p1");
+  klee_make_symbolic(&p2, sizeof(p2), "p2");
+
+  klee_assume(i < 4);
+
+  if (p1 < 8) {
+    if (i > 0)
+      a[i] = 'b';
+  }
+
+  if (p2 < 8) {
+    if (i < 3)
+      a[i] = 'a';
+  }
+
+  assert(a[0] == 'a');
+
+  return 0;
+}
+
+

--- a/basic/arraysimple5.c
+++ b/basic/arraysimple5.c
@@ -1,7 +1,7 @@
 /*
  * Copyright 2016 National University of Singapore
  *
- * Subsumption test with symbolic index. This exposes some supposedly
+ * Subsumption test with symbolic index. This exposed some supposedly
  * bounded variables appearing unbounded in subsumption check.
  */
 #include <klee/klee.h>

--- a/basic/arraysimple5.c
+++ b/basic/arraysimple5.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016 National University of Singapore
+ *
+ * Subsumption test with symbolic index. This exposes some supposedly
+ * bounded variables appearing unbounded in subsumption check.
+ */
+#include <klee/klee.h>
+#include <assert.h>
+
+int main() {
+  unsigned char a[5] = "aabb";
+  unsigned i, j;
+  int p1, p2, p3;
+
+  klee_make_symbolic(&i, sizeof(i), "i");
+  klee_make_symbolic(&j, sizeof(j), "j");  
+  klee_make_symbolic(&p1, sizeof(p1), "p1");
+  klee_make_symbolic(&p2, sizeof(p2), "p2");
+  klee_make_symbolic(&p3, sizeof(p3), "p3");
+
+  klee_assume(i < 4);
+  klee_assume(j < 4);
+
+  if (p1 < 8) {
+    a[i] = 'a';
+  } else {
+    if (j > 2)
+      a[j] = 'b';
+  }
+
+  if (p2 < 8) {
+    if (i > 2)
+      a[i] = 'a';
+  } else {
+    if (j > 2)
+      a[j] = 'c';
+  }
+
+  if (p3 < 8) {
+    if (i > 1)
+      a[i] = 'c';
+  } else {
+    if (j < 2)
+      a[j] = 'a';
+  }
+
+  if (i < 2) {
+    assert(a[i] == 'a');
+  }
+
+  return 0;
+}
+
+

--- a/basic/arraysimple6.c
+++ b/basic/arraysimple6.c
@@ -1,0 +1,50 @@
+/*
+ * Subsumption test with symbolic index. This exposed the issue that
+ * some memory allocations are not stored as interpolant.
+ *
+ * A simplified version of regexp_nonrecursive2.c.
+ */
+#include <klee/klee.h>
+
+static int matchhere(char *re, char *text) {
+  if (re[0] == '\0')
+    return 0;
+  if (re[1] == '*')
+    return 0;
+  if (*text!='\0' && (re[0]=='.' || re[0]==*text))
+    return 0;
+  return 0;
+}
+
+int match(char *re, char *text) {
+  do {
+    if (matchhere(re, text))
+      return 1;
+  } while (*text++ != '\0');
+  return 0;
+}
+
+/*
+ * Harness for testing with KLEE.
+ */
+
+// The size of the buffer to test with.
+#define SIZE 7
+
+int main() {
+  // The input regular expression.
+  char re[SIZE];
+  char str[6];
+
+  // Make the inputs symbolic. 
+  klee_make_symbolic(re, sizeof re, "re");
+  klee_make_symbolic(str, sizeof str, "str");
+
+  // Try to match against a constant string "hello".
+  str[5] = 0;
+
+  match(re, str);
+
+  return 0;
+}
+


### PR DESCRIPTION
They are `basic/arraysimple[4-6].c`.
