### PR TITLE
Updated Makefile.common for generating SVG instead of PDF tree images

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -38,10 +38,10 @@ clean:
 	time ${KLEE} ${KLEE_FLAGS} -output-dir=$@ $<
 	opt -analyze -dot-cfg $<
 	mv *.dot $@
-	# Create PDFs from *.dot files
+	# Create SVGs from *.dot files
 	for DOTFILE in $@/*.dot ; do \
-		PDFFILE=`echo -n $$DOTFILE | sed -e s/\.dot/\.pdf/ -` ; \
-		dot -Tpdf $$DOTFILE -o $$PDFFILE ; \
+		SVGFILE=`echo -n $$DOTFILE | sed -e s/\.dot/\.svg/ -` ; \
+		dot -Tsvg $$DOTFILE -o $$SVGFILE ; \
 	done
 
 # For running KLEE with STP without interpolation
@@ -49,10 +49,10 @@ clean:
 	time ${KLEE} ${KLEE_FLAGS} -select-solver=stp -output-dir=$@ $<
 	opt -analyze -dot-cfg $<
 	mv *.dot $@
-	# Create PDFs from .dot files
+	# Create SVGs from .dot files
 	for DOTFILE in $@/*.dot ; do \
-		PDFFILE=`echo -n $$DOTFILE | sed -e s/\.dot/\.pdf/ -` ; \
-		dot -Tpdf $$DOTFILE -o $$PDFFILE ; \
+		SVGFILE=`echo -n $$DOTFILE | sed -e s/\.dot/\.svg/ -` ; \
+		dot -Tsvg $$DOTFILE -o $$SVGFILE ; \
 	done
 
 .klee.inputs:


### PR DESCRIPTION
PDFs are bitmaps and they get blurry with large graphs. This issue does not happen with SVGs, which can be easily viewed in browsers.
