### PR TITLE
Added LD_LIBRARY_PATH setting to join/Makefile 

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -9,8 +9,8 @@ EXTRA_PATH=
 
 # Extra libraries that may be needed for running KLEE to be added to
 # LD_LIBRARY_PATH environment variable, e.g., the path of libz3.so
-EXTRA_LD_LIB=
-#EXTRA_LD_LIB=${HOME}/software/lib:${HOME}/software/stp-2.1.0/build/lib
+EXTRA_LD_LIBRARY_PATH=
+#EXTRA_LD_LIBRARY_PATH=${HOME}/software/lib:${HOME}/software/stp-2.1.0/build/lib
 
 # Where KLEE resides in the system
 KLEE_HOME=/usr/local/lib/tracerx

--- a/join/Makefile
+++ b/join/Makefile
@@ -17,11 +17,11 @@ clean: standard-clean
 
 # For testing -use-clpr option in loading multiple CLP(R) files
 test-use-clpr: join1.bc
-	time ${KLEE} ${KLEE_FLAGS} -use-clpr=dummy1.clpr -use-clpr=dummy2.clpr -output-dir=$@ $<
+	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=dummy1.clpr -use-clpr=dummy2.clpr -output-dir=$@ $<
 
 # For testing actual klee_join mechanism
 test-join: join2.bc
-	time ${KLEE} ${KLEE_FLAGS} -use-clpr=dummy1.clpr -output-dir=$@ $<
+	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=dummy1.clpr -output-dir=$@ $<
 
 test-count: count.bc
-	time ${KLEE} ${KLEE_FLAGS} -use-clpr=count.clpr -output-dir=$@ $<
+	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=count.clpr -output-dir=$@ $<


### PR DESCRIPTION
@feliciahalim This is so that `libclpr_api.so` can be found. This is done by setting `EXTRA_LD_LIBRARY_PATH` in `Makefile.common`. Also, I have renamed `EXTRA_LD_LIB` to `EXTRA_LD_LIBRARY_PATH` which I think is clearer.
