### PR TITLE
Added EXTRA_LD_LIBRARY_PATH to LD_LIBRARY_PATH in .bc.klee and .bc.st…

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -10,7 +10,7 @@ EXTRA_PATH=
 # Extra libraries that may be needed for running KLEE to be added to
 # LD_LIBRARY_PATH environment variable, e.g., the path of libz3.so
 EXTRA_LD_LIBRARY_PATH=
-#EXTRA_LD_LIBRARY_PATH=${HOME}/software/clpr-1.2l/lib:${HOME}/software/stp-2.1.0/build/lib:${HOME}/z3/z3_install/lib
+#EXTRA_LD_LIBRARY_PATH=${HOME}/software/clpr-1.2l/lib:${HOME}/software/stp-2.1.0/build/lib:${HOME}/z3/z3_install/lib:${HOME}/software/lib
 
 # Where KLEE resides in the system
 KLEE_HOME=/usr/local/lib/tracerx
@@ -60,7 +60,7 @@ standard-clean:
 
 # For running KLEE with Z3 and interpolation
 .bc.klee:
-	time ${KLEE} ${KLEE_FLAGS} -output-dir=$@ $<
+	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -output-dir=$@ $<
 	opt -analyze -dot-cfg $<
 	mv *.dot $@
 	# Create SVGs from *.dot files
@@ -94,7 +94,7 @@ standard-clean:
 	fi
 # For running KLEE with STP without interpolation
 .bc.stpklee:
-	time ${KLEE} ${KLEE_FLAGS} -select-solver=stp -output-dir=$@ $<
+	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -select-solver=stp -output-dir=$@ $<
 	opt -analyze -dot-cfg $<
 	mv *.dot $@
 	# Create SVGs from .dot files


### PR DESCRIPTION
…pklee targets in `Makefile.common`. This is so that they are used for running Tracer-X KLEE for e.g., targets in the `basic` directory, even when LD_LIBRARY_PATH environment variable is not set.
