### PR TITLE
Preserve the integrity of non-shared .gcda for robustness

### DIFF
--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -196,7 +196,7 @@ sandbox:
 			gcov -o $$GCOV_OBJ $* ; \
 		done \
 	) > ${CURDIR}/$@/GcovLog.txt 2>&1
-	rm -f ${COREUTILS_GCOV_DIR}/src/*.gcda; \
+	rm -f ${COREUTILS_GCOV_DIR}/src/*.gcda; 
 
 %.stpklee: build sandbox
 	@echo =================================================================
@@ -270,7 +270,7 @@ sandbox:
 			gcov -o $$GCOV_OBJ $* ; \
 		done \
 	) > ${CURDIR}/$@/GcovLog.txt 2>&1
-	rm -f ${COREUTILS_GCOV_DIR}/src/*.gcda; \
+	rm -f ${COREUTILS_GCOV_DIR}/src/*.gcda; 
 
 clean:
 	rm -rf ${KLEE_TARGETS} ${KLEESTP_TARGETS} sandbox sandbox.temps test.env

--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -189,48 +189,14 @@ sandbox:
 	else \
 		GCOV_OBJECTS=$* ; \
 	fi ; \
-	if   [ $* = "arch" ] && [ -e ${COREUTILS_GCOV_DIR}/src/uname.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp uname.gcda uname_temp.gcda ; \
-	elif [ $* = "uname" ] && [ -e ${COREUTILS_GCOV_DIR}/src/uname.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp uname.gcda uname_temp.gcda ; \
-	elif [ $* = "dir" ] && [ -e ${COREUTILS_GCOV_DIR}/src/ls.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp ls.gcda ls_temp.gcda ; \
-	elif [ $* = "vdir" ] && [ -e ${COREUTILS_GCOV_DIR}/src/ls.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp ls.gcda ls_temp.gcda ; \
-	elif [ $* = "ls" ] && [ -e ${COREUTILS_GCOV_DIR}/src/ls.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp ls.gcda ls_temp.gcda ; \
-	elif [ $* = "sha1sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	elif [ $* = "sha224sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	elif [ $* = "sha256sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	elif [ $* = "sha384sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	elif [ $* = "sha512sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	else \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp $*.gcda $*_temp.gcda ; \
-	fi; \
+	rm -f ${COREUTILS_GCOV_DIR}/src/*.gcda; \
 	( cd ${COREUTILS_GCOV_DIR}/src ; \
 		${KLEE_REPLAY} $* ${CURDIR}/$@/*.ktest ; \
 		for GCOV_OBJ in $$GCOV_OBJECTS ; do \
 			gcov -o $$GCOV_OBJ $* ; \
 		done \
 	) > ${CURDIR}/$@/GcovLog.txt 2>&1
-	if [ -e ${COREUTILS_GCOV_DIR}/src/uname_temp.gcda ] ; then \
-		rm ${COREUTILS_GCOV_DIR}/src/uname.gcda ; \
-		mv ${COREUTILS_GCOV_DIR}/src/uname_temp.gcda ${COREUTILS_GCOV_DIR}/src/uname.gcda ; \
-	elif [ -e ${COREUTILS_GCOV_DIR}/src/ls_temp.gcda ] ; then \
-		rm ${COREUTILS_GCOV_DIR}/src/ls.gcda ; \
-		mv ${COREUTILS_GCOV_DIR}/src/ls_temp.gcda ${COREUTILS_GCOV_DIR}/src/ls.gcda ; \
-	elif [ -e ${COREUTILS_GCOV_DIR}/src/md5sum_temp.gcda ] ; then \
-		rm ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ; \
-		mv ${COREUTILS_GCOV_DIR}/src/md5sum_temp.gcda ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ; \
-	else \
-		rm ${COREUTILS_GCOV_DIR}/src/$*.gcda ; \
-		mv ${COREUTILS_GCOV_DIR}/src/$*_temp.gcda ${COREUTILS_GCOV_DIR}/src/$*.gcda ; \
-	fi; \
+	rm -f ${COREUTILS_GCOV_DIR}/src/*.gcda; \
 
 %.stpklee: build sandbox
 	@echo =================================================================
@@ -297,48 +263,14 @@ sandbox:
 	else \
 		GCOV_OBJECTS=$* ; \
 	fi ; \
-	if   [ $* = "arch" ] && [ -e ${COREUTILS_GCOV_DIR}/src/uname.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp uname.gcda uname_temp.gcda ; \
-	elif [ $* = "uname" ] && [ -e ${COREUTILS_GCOV_DIR}/src/uname.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp uname.gcda uname_temp.gcda ; \
-	elif [ $* = "dir" ] && [ -e ${COREUTILS_GCOV_DIR}/src/ls.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp ls.gcda ls_temp.gcda ; \
-	elif [ $* = "vdir" ] && [ -e ${COREUTILS_GCOV_DIR}/src/ls.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp ls.gcda ls_temp.gcda ; \
-	elif [ $* = "ls" ] && [ -e ${COREUTILS_GCOV_DIR}/src/ls.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp ls.gcda ls_temp.gcda ; \
-	elif [ $* = "sha1sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	elif [ $* = "sha224sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	elif [ $* = "sha256sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	elif [ $* = "sha384sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	elif [ $* = "sha512sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
-	else \
-	     cd ${COREUTILS_GCOV_DIR}/src/; cp $*.gcda $*_temp.gcda ; \
-	fi; \
+	rm -f ${COREUTILS_GCOV_DIR}/src/*.gcda; \
 	( cd ${COREUTILS_GCOV_DIR}/src ; \
 		${KLEE_REPLAY} $* ${CURDIR}/$@/*.ktest ; \
 		for GCOV_OBJ in $$GCOV_OBJECTS ; do \
 			gcov -o $$GCOV_OBJ $* ; \
 		done \
 	) > ${CURDIR}/$@/GcovLog.txt 2>&1
-	if [ -e ${COREUTILS_GCOV_DIR}/src/uname_temp.gcda ] ; then \
-		rm ${COREUTILS_GCOV_DIR}/src/uname.gcda ; \
-		mv ${COREUTILS_GCOV_DIR}/src/uname_temp.gcda ${COREUTILS_GCOV_DIR}/src/uname.gcda ; \
-	elif [ -e ${COREUTILS_GCOV_DIR}/src/ls_temp.gcda ] ; then \
-		rm ${COREUTILS_GCOV_DIR}/src/ls.gcda ; \
-		mv ${COREUTILS_GCOV_DIR}/src/ls_temp.gcda ${COREUTILS_GCOV_DIR}/src/ls.gcda ; \
-	elif [ -e ${COREUTILS_GCOV_DIR}/src/md5sum_temp.gcda ] ; then \
-		rm ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ; \
-		mv ${COREUTILS_GCOV_DIR}/src/md5sum_temp.gcda ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ; \
-	else \
-		rm ${COREUTILS_GCOV_DIR}/src/$*.gcda ; \
-		mv ${COREUTILS_GCOV_DIR}/src/$*_temp.gcda ${COREUTILS_GCOV_DIR}/src/$*.gcda ; \
-	fi; \
+	rm -f ${COREUTILS_GCOV_DIR}/src/*.gcda; \
 
 clean:
 	rm -rf ${KLEE_TARGETS} ${KLEESTP_TARGETS} sandbox sandbox.temps test.env

--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -18,7 +18,7 @@ KLEE_COREUTILS_OPTIONS=--simplify-sym-indices --write-cvcs --write-cov --output-
 	--max-memory=1000 --disable-inlining --optimize --use-forked-solver \
 	--use-cex-cache --libc=uclibc --posix-runtime \
 	--allow-external-sym-calls --only-output-states-covering-new \
-	--max-sym-array-size=4096 --max-instruction-time=30. --max-time=10. \
+	--max-sym-array-size=4096 --max-instruction-time=30. --max-time=3600. \
 	--watchdog --max-memory-inhibit=false --max-static-fork-pct=1 \
 	--max-static-solve-pct=1 --max-static-cpfork-pct=1 --switch-type=internal \
 	--randomize-fork --search=random-path --search=nurs:covnew \

--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -18,7 +18,7 @@ KLEE_COREUTILS_OPTIONS=--simplify-sym-indices --write-cvcs --write-cov --output-
 	--max-memory=1000 --disable-inlining --optimize --use-forked-solver \
 	--use-cex-cache --libc=uclibc --posix-runtime \
 	--allow-external-sym-calls --only-output-states-covering-new \
-	--max-sym-array-size=4096 --max-instruction-time=30. --max-time=3600. \
+	--max-sym-array-size=4096 --max-instruction-time=30. --max-time=10. \
 	--watchdog --max-memory-inhibit=false --max-static-fork-pct=1 \
 	--max-static-solve-pct=1 --max-static-cpfork-pct=1 --switch-type=internal \
 	--randomize-fork --search=random-path --search=nurs:covnew \
@@ -209,6 +209,8 @@ sandbox:
 	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
 	elif [ $* = "sha512sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
 	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
+	else \
+	     cd ${COREUTILS_GCOV_DIR}/src/; cp $*.gcda $*_temp.gcda ; \
 	fi; \
 	( cd ${COREUTILS_GCOV_DIR}/src ; \
 		${KLEE_REPLAY} $* ${CURDIR}/$@/*.ktest ; \
@@ -225,6 +227,9 @@ sandbox:
 	elif [ -e ${COREUTILS_GCOV_DIR}/src/md5sum_temp.gcda ] ; then \
 		rm ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ; \
 		mv ${COREUTILS_GCOV_DIR}/src/md5sum_temp.gcda ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ; \
+	else \
+		rm ${COREUTILS_GCOV_DIR}/src/$*.gcda ; \
+		mv ${COREUTILS_GCOV_DIR}/src/$*_temp.gcda ${COREUTILS_GCOV_DIR}/src/$*.gcda ; \
 	fi; \
 
 %.stpklee: build sandbox
@@ -312,6 +317,8 @@ sandbox:
 	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
 	elif [ $* = "sha512sum" ] && [ -e ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ] ; then \
 	     cd ${COREUTILS_GCOV_DIR}/src/; cp md5sum.gcda md5sum_temp.gcda ; \
+	else \
+	     cd ${COREUTILS_GCOV_DIR}/src/; cp $*.gcda $*_temp.gcda ; \
 	fi; \
 	( cd ${COREUTILS_GCOV_DIR}/src ; \
 		${KLEE_REPLAY} $* ${CURDIR}/$@/*.ktest ; \
@@ -328,6 +335,9 @@ sandbox:
 	elif [ -e ${COREUTILS_GCOV_DIR}/src/md5sum_temp.gcda ] ; then \
 		rm ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ; \
 		mv ${COREUTILS_GCOV_DIR}/src/md5sum_temp.gcda ${COREUTILS_GCOV_DIR}/src/md5sum.gcda ; \
+	else \
+		rm ${COREUTILS_GCOV_DIR}/src/$*.gcda ; \
+		mv ${COREUTILS_GCOV_DIR}/src/$*_temp.gcda ${COREUTILS_GCOV_DIR}/src/$*.gcda ; \
 	fi; \
 
 clean:


### PR DESCRIPTION
Suppose that we modify Tracer-X in-between coreutils runs, although on the same coreutils program, the coverage result may differ. Reusing the .gcda from the previous run before Tracer-X modification may confuse the person doing the experiment.

Thanks @domainexpert for the advice.
