### PR TITLE
Uses new -clpr-log option for logging CLP(R) in /tmp/clpr-XXXXXX

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -9,7 +9,7 @@ EXTRA_PATH=
 
 # Extra libraries that may be needed for running KLEE to be added to
 # LD_LIBRARY_PATH environment variable, e.g., the path of libz3.so
-EXTRA_LD_LIBRARY_PATH=
+EXTRA_LD_LIBRARY_PATH=/usr/local/lib
 #EXTRA_LD_LIBRARY_PATH=${HOME}/software/clpr-1.2l/lib:${HOME}/software/stp-2.1.0/build/lib:${HOME}/z3/z3_install/lib:${HOME}/software/lib
 
 # Where KLEE resides in the system

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The examples in the `join` subdirectory requires Tracer-X KLEE to be compiled wi
 
   `make test-join`
 
-- For running Tracer-X KLEE with `count.c`, a larger example to test the subsumption ability of Tracer-X KLEE with `klee_join`.
+- Make `test-count` and `test-sum` targets are for running Tracer-X KLEE with larger examples to test the subsumption ability using `klee_join`. Run, e.g.:
 
   `make test-count`
 

--- a/join/Makefile
+++ b/join/Makefile
@@ -18,21 +18,21 @@ clean: standard-clean
 # For testing -use-clpr option in loading multiple CLP(R) files
 test-use-clpr: join1.bc
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=dummy1.clpr -use-clpr=dummy2.clpr -output-dir=$@ $<
-	mv /tmp/clpr-* $@/
+	mv -f /tmp/clpr-* $@/clpr.log
 
 # For testing actual klee_join mechanism
 test-join: join2.bc
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=dummy1.clpr -output-dir=$@ $<
-	mv /tmp/clpr-* $@/
+	mv -f /tmp/clpr-* $@/clpr.log
 
 # For testing the count example
 test-count: count.bc
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=count.clpr -output-dir=$@ $<
-	mv /tmp/clpr-* $@/
+	mv -f /tmp/clpr-* $@/clpr.log
 
 # For testing the sum example
 test-sum: sum.bc
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=sum.clpr -output-dir=$@ $<
-	mv /tmp/clpr-* $@/
+	mv -f /tmp/clpr-* $@/clpr.log
 
 

--- a/join/Makefile
+++ b/join/Makefile
@@ -4,7 +4,7 @@
 
 # We enable execution tree (tree.dot) output as the examples
 # in this directory are small.
-EXTRA_OPTIONS=-output-tree -interpolation-stat -write-pcs -use-query-log=all:pc,all:smt2
+EXTRA_OPTIONS=-output-tree -interpolation-stat -write-pcs -use-query-log=all:pc,all:smt2 -clpr-log
 
 JOIN_TARGETS=test-use-clpr test-join test-count
 
@@ -18,10 +18,14 @@ clean: standard-clean
 # For testing -use-clpr option in loading multiple CLP(R) files
 test-use-clpr: join1.bc
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=dummy1.clpr -use-clpr=dummy2.clpr -output-dir=$@ $<
+	mv /tmp/clpr-* $@/
 
 # For testing actual klee_join mechanism
 test-join: join2.bc
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=dummy1.clpr -output-dir=$@ $<
+	mv /tmp/clpr-* $@/
 
+# For testing the count example
 test-count: count.bc
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} -use-clpr=count.clpr -output-dir=$@ $<
+	mv /tmp/clpr-* $@/

--- a/join/count.c
+++ b/join/count.c
@@ -10,7 +10,7 @@
 
 int main() {
   char a[SIZE];
-  unsigned i, count1, count2;
+  unsigned i, count1 = 0, count2 = 0;
 
   klee_make_symbolic(a, SIZE * sizeof(char), "a");
 

--- a/join/count.clpr
+++ b/join/count.clpr
@@ -1,3 +1,6 @@
+% Count predicate for count example
+%
+% Copyright 2016 National University of Singapore
 
 count(H, A_Ptr, A_Ptr, 1) :-
 	V < 0, mcc_select(H, A_Ptr, V).

--- a/join/count.clpr
+++ b/join/count.clpr
@@ -2,22 +2,25 @@
 %
 % Copyright 2016 National University of Singapore
 
-count(H, A_Ptr, A_Ptr, 1) :-
+count(H, A_Ptr, Index, C) :-
+    count_aux(H, A_Ptr, A_Ptr + (Index * 4), C).
+
+count_aux(H, A_Ptr, A_Ptr, 1) :-
 	V < 0, mcc_select(H, A_Ptr, V).
-count(H, A_Ptr, A_Ptr, 1) :-
+count_aux(H, A_Ptr, A_Ptr, 1) :-
 	V > 0, mcc_select(H, A_Ptr, V).
-count(H, A_Ptr, A_Ptr, 0) :-
+count_aux(H, A_Ptr, A_Ptr, 0) :-
  	V = 0, mcc_select(H, A_Ptr, V).
-count(H, A_Ptr, E_Ptr, C + 1) :-
+count_aux(H, A_Ptr, E_Ptr, C + 1) :-
 	A_Ptr < E_Ptr,
 	V < 0, mcc_select(H, E_Ptr, V),
-	count(H, A_Ptr, E_Ptr - 1, C).
-count(H, A_Ptr, E_Ptr, C + 1) :-
+	count_aux(H, A_Ptr, E_Ptr - 4, C).
+count_aux(H, A_Ptr, E_Ptr, C + 1) :-
 	A_Ptr < E_Ptr,
 	V > 0, mcc_select(H, E_Ptr, V),
-	count(H, A_Ptr, E_Ptr - 1, C).
-count(H, A_Ptr, E_Ptr, C) :-
+	count_aux(H, A_Ptr, E_Ptr - 4, C).
+count_aux(H, A_Ptr, E_Ptr, C) :-
 	A_Ptr < E_Ptr,
 	V = 0, mcc_select(H, E_Ptr, V),
-	count(H, A_Ptr, E_Ptr - 1, C).
+	count_aux(H, A_Ptr, E_Ptr - 4, C).
 

--- a/join/count.clpr
+++ b/join/count.clpr
@@ -3,7 +3,7 @@
 % Copyright 2016 National University of Singapore
 
 count(H, A_Ptr, Index, C) :-
-    count_aux(H, A_Ptr, A_Ptr + (Index * 4), C).
+    count_aux(H, A_Ptr, A_Ptr + Index, C).
 
 count_aux(H, A_Ptr, A_Ptr, 1) :-
 	V < 0, mcc_select(H, A_Ptr, V).
@@ -14,13 +14,13 @@ count_aux(H, A_Ptr, A_Ptr, 0) :-
 count_aux(H, A_Ptr, E_Ptr, C + 1) :-
 	A_Ptr < E_Ptr,
 	V < 0, mcc_select(H, E_Ptr, V),
-	count_aux(H, A_Ptr, E_Ptr - 4, C).
+	count_aux(H, A_Ptr, E_Ptr - 1, C).
 count_aux(H, A_Ptr, E_Ptr, C + 1) :-
 	A_Ptr < E_Ptr,
 	V > 0, mcc_select(H, E_Ptr, V),
-	count_aux(H, A_Ptr, E_Ptr - 4, C).
+	count_aux(H, A_Ptr, E_Ptr - 1, C).
 count_aux(H, A_Ptr, E_Ptr, C) :-
 	A_Ptr < E_Ptr,
 	V = 0, mcc_select(H, E_Ptr, V),
-	count_aux(H, A_Ptr, E_Ptr - 4, C).
+	count_aux(H, A_Ptr, E_Ptr - 1, C).
 

--- a/join/dummy2.clpr
+++ b/join/dummy2.clpr
@@ -2,5 +2,7 @@
 %
 % Copyright 2016 National University of Singapore
 
-dummy2(X) :- X = 0.
-dummy2(X + 1) :- X > 0, dummy2(X).
+% Note the first argument H representing global heap
+% is mandatory.
+dummy2(_H, X) :- X = 0.
+dummy2(H, X + 1) :- X > 0, dummy2(H, X).

--- a/join/sum.c
+++ b/join/sum.c
@@ -1,26 +1,25 @@
 /*
  * Copyright 2016 National University of Singapore
- *
- * Author: Joxan Jaffar
  */
 #include <klee/klee.h>
 #include <assert.h>
 #include <stdio.h>
+
 #define SIZE 3
 
 int main() {
   char a[SIZE];
-  unsigned i, sum1, sum2;
+  unsigned i, sum1 = 0, sum2 = 0;
 
   klee_make_symbolic(a, SIZE * sizeof(char), "a");
 
   for (i = 0; i < SIZE; ++i) {
-    if(a[i] > 0) sum1 += a[i];
+    if (a[i] > 0) sum1 += a[i];
   }
 
   for (i = 0; i < SIZE; ++i) {
     sum2 += a[i];
-    klee_join("sum", a, sum2);
+    klee_join("sum", a, i, sum2);
   }
 
   assert(sum1 == sum2); // The assertion should be violated because sum1 only sum positive numbers, while sum2 sum all the numbers.

--- a/join/sum.clpr
+++ b/join/sum.clpr
@@ -1,4 +1,8 @@
-sum([], 0).
-sum([H|T], Sum) :-
-   sum(T, Rest),
-   Sum is H + Rest.
+% Sum/4 predicate specifying the behavior of "sum"
+%
+% Copyright 2016 National University of Singapore
+
+sum(_H, _A_Ptr, 0, 0).
+sum(H, A_Ptr, Index, Number + Rest) :-
+    mcc_select(H, A_Ptr + Index, Number),
+    sum(H, A_Ptr, Index - 1, Rest).


### PR DESCRIPTION
This is for examples in the `join` subdirectory. It also includes fixes for the CLP predicates as well as for the examples in `join`.
