### PR TITLE
No-Error Check

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -85,7 +85,10 @@ standard-clean:
 	if [ -e error.dat ]; then \
 		REFERENCE_ERROR=`grep $*.c error.dat | sed 's/^[a-z0-9_]*\.c\t\+//' - ` ; \
 		if [ x$$REFERENCE_ERROR != x ] ; then \
-			ACTUAL_ERROR=`ls $@/*.err | wc -l` ; \
+			ACTUAL_ERROR=0 ; \
+			if [ -e $@/*.err ] ; then \
+				ACTUAL_ERROR=`ls $@/*.err | wc -l` ; \
+			fi ; \
 			if [ x$$REFERENCE_ERROR != x$$ACTUAL_ERROR ] ; then \
 				echo ERROR: Error count \($$ACTUAL_ERROR\) disagrees with reference data for $*.c \($$REFERENCE_ERROR\) ; \
 				exit 1 ; \

--- a/basic/error.dat
+++ b/basic/error.dat
@@ -1,6 +1,35 @@
 # Program		Errors
+addition.c		0
+addition_safe10.c	0
+addition_safe1.c	0
+addition_safe2.c	0
+addition_safe3.c	0
+addition_safe4.c	0
+addition_safe5.c	0
+addition_safe6.c	0
+addition_safe8.c	0
+addition_safe9.c	0
 addition_unsafe1.c	1
 addition_unsafe2.c	1
+argument1.c		0
 argument2.c		1
+arraysimple1.c		0
+arraysimple2.c		0
+arraysimple3.c		0
+arraysimple4.c		0
+arraysimple5.c		0
+arraysimple6.c		0
+branch.c		0
+bubble.c		0
+even.c			0
+interproc.c		0
+loop_safe1.c		0
+loop_safe2.c		0
 loop_unsafe1.c		1
 malloc1.c		1
+polynomial.c		0
+regexp_nonrecursive1.c	0
+regexp_nonrecursive2.c	0
+regexp_nonrecursive3.c	0
+sp.c			0
+


### PR DESCRIPTION
Added no-error check mechanism to basic examples. Previously, Makefile.common only checks for existence of errors. Now it also checks for non-existence of errors.
