### PR TITLE
Remove number of solver calls field in Coreutils and Scalability Makefile

### DIFF
--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -412,7 +412,7 @@ exp-201609:
 # This target is used for collecting data from experiment exp-201609 result into log-exp-201609.csv file.
 csv-exp-201609:
 	rm -f log-exp-201609.csv
-	echo "Directory,Time, #instructions,#completed paths,#error paths,#subsumed paths,#program exit paths,Average branching depth of completed paths,Average branching depth of subsumption paths,Average instructions of completed paths, Average instructions of subsumed paths,Icov,Bcov,Gcov,SLOC,Time for actual solver calls in subsumption check (ms),Number of solver calls for subsumption check,Number of solver calls for subsumption check that resulted in subsumption failure,Average table entries per subsumption checkpoint,Average solver calls per subsumption check,Number of solver calls,Number of subsumption checks" >> log-exp-201609.csv; \
+	echo "Directory,Time, #instructions,#completed paths,#error paths,#subsumed paths,#program exit paths,Average branching depth of completed paths,Average branching depth of subsumption paths,Average instructions of completed paths, Average instructions of subsumed paths,Icov,Bcov,Gcov,SLOC,Time for actual solver calls in subsumption check (ms),Number of solver calls for subsumption check,Number of solver calls for subsumption check that resulted in subsumption failure,Average table entries per subsumption checkpoint,Average solver calls per subsumption check,Number of subsumption checks" >> log-exp-201609.csv; \
 	for ext in .klee1 .klee2 .tracerx1 .tracerx2 .tracerx3 .tracerx4; \
 	do \
 		for program in cut expand join sum tail tsort uniq wc factor seq comm dirname head pathchk split; \
@@ -460,8 +460,6 @@ csv-exp-201609:
 				grep "Average table entries per subsumption checkpoint" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | tr -d '\n' >> log-exp-201609.csv; \
 				printf ", " >> log-exp-201609.csv; \
 				grep "Average solver calls per subsumption check" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | tr -d '\n' >> log-exp-201609.csv; \
-				printf ", " >> log-exp-201609.csv; \
-				grep "KLEE: done:     Number of solver calls" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | sed -E  's/(.*)\)(.*)/\2/' | tr -d '\n' >> log-exp-201609.csv; \
 				printf ", " >> log-exp-201609.csv; \
 				grep "KLEE: done:     Number of subsumption checks" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | tr -d '\n' >> log-exp-201609.csv; \
 				printf "\n" >> log-exp-201609.csv; \

--- a/scalability/Makefile
+++ b/scalability/Makefile
@@ -138,7 +138,7 @@ exp-201609:
 # This target is used for collecting data from experiment exp-201609 result into log-exp-201609.csv file.
 csv-exp-201609:
 	rm -f log-exp-201609.csv
-	echo "Directory,Time, #instructions,#completed paths,#error paths,#subsumed paths,#program exit paths,Average branching depth of completed paths,Average branching depth of subsumption paths,Average instructions of completed paths, Average instructions of subsumed paths,Icov,Bcov,SLOC,Time for actual solver calls in subsumption check (ms),Number of solver calls for subsumption check,Number of solver calls for subsumption check that resulted in subsumption failure,Average table entries per subsumption checkpoint,Average solver calls per subsumption check,Number of solver calls,Number of subsumption checks" >> log-exp-201609.csv; \
+	echo "Directory,Time, #instructions,#completed paths,#error paths,#subsumed paths,#program exit paths,Average branching depth of completed paths,Average branching depth of subsumption paths,Average instructions of completed paths, Average instructions of subsumed paths,Icov,Bcov,SLOC,Time for actual solver calls in subsumption check (ms),Number of solver calls for subsumption check,Number of solver calls for subsumption check that resulted in subsumption failure,Average table entries per subsumption checkpoint,Average solver calls per subsumption check,Number of subsumption checks" >> log-exp-201609.csv; \
 	for ext in .klee1 .klee2 .tracerx1 .tracerx2 .tracerx3 .tracerx4; \
 	do \
 		for program in Regexp RegexpSize10 RegexpSize15 RegexpSize8 RegexpSize9 bubble12 bubble12_unsafe bubble9 bubble9_unsafe; \
@@ -182,8 +182,6 @@ csv-exp-201609:
 				grep "Average table entries per subsumption checkpoint" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | tr -d '\n' >> log-exp-201609.csv; \
 				printf ", " >> log-exp-201609.csv; \
 				grep "Average solver calls per subsumption check" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | tr -d '\n' >> log-exp-201609.csv; \
-				printf ", " >> log-exp-201609.csv; \
-				grep "KLEE: done:     Number of solver calls" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | sed -E  's/(.*)\)(.*)/\2/' | tr -d '\n' >> log-exp-201609.csv; \
 				printf ", " >> log-exp-201609.csv; \
 				grep "KLEE: done:     Number of subsumption checks" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | tr -d '\n' >> log-exp-201609.csv; \
 				printf "\n" >> log-exp-201609.csv; \


### PR DESCRIPTION
This PR is related to : https://github.com/tracer-x/klee/pull/144, as  `number of solver calls` would be removed.
