### PR TITLE
Added directory location of libz3.so on paella server in Makefile.common

### DIFF
--- a/Makefile.common
+++ b/Makefile.common
@@ -9,7 +9,7 @@ EXTRA_PATH=
 
 # Extra libraries that may be needed for running KLEE to be added to
 # LD_LIBRARY_PATH environment variable, e.g., the path of libz3.so
-EXTRA_LD_LIBRARY_PATH=/usr/local/lib
+EXTRA_LD_LIBRARY_PATH=/usr/local/lib:/usr/local/lib/z3/lib
 #EXTRA_LD_LIBRARY_PATH=${HOME}/software/clpr-1.2l/lib:${HOME}/software/stp-2.1.0/build/lib:${HOME}/z3/z3_install/lib:${HOME}/software/lib
 
 # Where KLEE resides in the system


### PR DESCRIPTION
To make Makefile.common's default paths to be consistently that of paella server's configuration.
