### PR TITLE
Corrected reference subsumption count for basic/addition_safe8.c

### DIFF
--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -7,7 +7,7 @@ addition_safe3.c	0
 addition_safe4.c	4
 addition_safe5.c	4
 addition_safe6.c	4
-addition_safe8.c	4
+addition_safe8.c	5
 addition_safe9.c	4
 addition_unsafe1.c	4
 addition_unsafe2.c	4


### PR DESCRIPTION
In the new version of Tracer-X, this should be 5 instead of 4, although 5 does not mean it is better, see tracer-x/klee#146.
