### PR TITLE
Corrected options for .klee1 and .klee2 targets in coreutils/Makefile

### DIFF
--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -145,10 +145,10 @@ sandbox:
 	)
 
 %.klee1 : 
-	KLEE_COREUTILS_MORE_OPTIONS="--search=dfs --search=nurs:covnew -solver-backend=stp -max-time=7200 -write-paths" OUTPUT_DIR=${CURDIR}/$@ make $*.klee-exp-201609
+	KLEE_COREUTILS_MORE_OPTIONS="--search=dfs -solver-backend=stp -max-time=7200 -write-paths" OUTPUT_DIR=${CURDIR}/$@ make $*.klee-exp-201609
 
 %.klee2 : 
-	KLEE_COREUTILS_MORE_OPTIONS="--search=dfs --search=nurs:covnew -solver-backend=z3 -no-interpolation -max-time=7200 -write-paths" OUTPUT_DIR=${CURDIR}/$@ make $*.klee-exp-201609
+	KLEE_COREUTILS_MORE_OPTIONS="--search=dfs -solver-backend=z3 -no-interpolation -max-time=7200 -write-paths" OUTPUT_DIR=${CURDIR}/$@ make $*.klee-exp-201609
 
 %.klee3 : 
 	KLEE_COREUTILS_MORE_OPTIONS="--search=random-path --search=nurs:covnew -solver-backend=stp -max-time=7200 -write-paths" OUTPUT_DIR=${CURDIR}/$@ make $*.klee-exp-201609


### PR DESCRIPTION
Removed --search=nurs:covnew option from the targets.
