### PR TITLE
Removed entry for pointer_struct5.c in basic/subsumption.dat

### DIFF
--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -41,7 +41,6 @@ pointer_struct1.c	0
 pointer_struct2.c	0
 pointer_struct3.c	0
 pointer_struct4.c	0
-pointer_struct5.c	76
 pointer_struct6.c	0
 pointer_symbolic.c	0
 polynomial.c		0


### PR DESCRIPTION
@rasoolmaghareh The subsumption check result is actually nondeterministic (it's still 67 on my machine). Nondeterminism is possible for this example due to the existence of `malloc()` call within it. As is known, the return value of `malloc()` is pseudo-nondeterministic. KLEE sometimes reuse the returned address of `malloc()` between paths, but sometimes it does not. The entry in `subsumption.dat` is removed to avoid check failure.