### PR TITLE
Added license text

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,27 @@
+Copyright (c) 2015-2017 National University of Singapore. All rights reserved.
+
+Permission is hereby granted, free of charge, to any person obtaining
+a copy of this software and associated documentation files (the
+"Software"), to deal with the Software without restriction, including
+without limitation the rights to use, copy, modify, merge, publish,
+distribute, sublicense, and/or sell copies of the Software, and to
+permit persons to whom the Software is furnished to do so, subject to
+the following conditions: Redistributions of source code must retain
+the above copyright notice, this list of conditions and the following
+disclaimers. Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following
+disclaimers in the documentation and/or other materials provided with
+the distribution. Neither the names National University of Singapore,
+nor the names of its contributors may be used to endorse or promote
+products derived from this Software without specific prior written
+permission.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF
+MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+NONINFRINGEMENT. IN NO EVENT SHALL THE CONTRIBUTORS OR COPYRIGHT
+HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS WITH THE
+SOFTWARE.
+

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 Simple examples for running with Tracer-X KLEE
 ----------------------------------------------
 
-Copyright 2015-2017 National University of Singapore
+Copyright 2015-2017 National University of Singapore. See LICENSE.md for license information.
 
 This software includes third-party software, including some sample programs are from LLBMC 2013.1 distribution modified for running with KLEE, GNU Coreutils 6.10, and portions of libPNG. Their license information is included in the `license/LLBMC_LICENSE`, `license/COPYING`, and `license/LIBPNG_LICENSE`.
 


### PR DESCRIPTION
It is probably time we add a license text, so others can also use our examples for their work. The LICENSE.md contains an open-source MIT-style license.