### PR TITLE
Display klee-stats output after each run and corrected Makefile comments

### DIFF
--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -106,9 +106,9 @@ standard-clean:
 # For running KLEE with Z3 and interpolation
 .bc.tx:
 	SOLVER_FLAGS="-solver-backend=z3" OUTPUT_DIR=$@ make $*.klee-out
-	# The following is to catch any difference in subsumption
-	# number for regression testing purposes
-	@if [ -e subsumption.dat ]; then \
+# The following is to catch any difference in subsumption number for
+# regression testing purposes
+	 @if [ -e subsumption.dat ]; then \
 		REFERENCE_SUBSUMPTION=`grep $*.c subsumption.dat | sed 's/^[a-z0-9_\-]*\.c\t\+//' - ` ; \
 		if [ x$$REFERENCE_SUBSUMPTION != x ] ; then \
 			ACTUAL_SUBSUMPTION=`grep subsumed $@/tree.dot | wc -l` ; \
@@ -118,8 +118,8 @@ standard-clean:
 			fi ; \
 		fi ; \
 	fi
-	# The following is to catch any difference in error report
-	# number for regression testing purposes
+# The following is to catch any difference in error report number for
+# regression testing purposes
 	@if [ -e error.dat ]; then \
 		REFERENCE_ERROR=`grep $*.c error.dat | sed 's/^[a-z0-9_\-]*\.c\t\+//' - ` ; \
 		if [ x$$REFERENCE_ERROR != x ] ; then \
@@ -146,7 +146,15 @@ standard-clean:
 	@LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_FLAGS} $$SOLVER_FLAGS -output-dir=$$OUTPUT_DIR $< ${PROGRAM_OPTIONS}
 	@opt -analyze -dot-cfg $<
 	@mv *.dot $$OUTPUT_DIR
-	# Create SVGs from .dot files
+####################################################################
+# KLEE-STATS Statistics                                            #
+#                                                                  #
+# KLEE displays a low coverage using klee-stats on small examples, #
+# due to additional code added.  The additional code is displayed  #
+# in <klee_output_dir>/assembly.ll.                                #
+####################################################################
+	@${KLEE_STATS} $$OUTPUT_DIR
+# Create SVGs from .dot files
 	@for DOTFILE in $$OUTPUT_DIR/*.dot ; do \
 		SVGFILE=`echo -n $$DOTFILE | sed -e s/\.dot/\.svg/ -` ; \
 		timeout ${SVG_CREATION_TIMEOUT}s dot -Tsvg $$DOTFILE -o $$SVGFILE ; \
@@ -168,20 +176,12 @@ standard-clean:
 
 .bc.cov:
 	@make $*.klee-out
-	####################################################################
-	# KLEE-STATS Statistics                                            #
-	#                                                                  #
-	# KLEE displays a low coverage using klee-stats on small examples, #
-	# due to additional code added.  The additional code is displayed  #
-	# in <klee_output_dir>/assembly.ll.                                #
-	####################################################################
-	${KLEE_STATS} $$OUTPUT_DIR
-	####################################################################
-	# llvm-cov Statistics for line coverage                            #
-	#                                                                  #
-	# See the generated .stpcov file for the detailed execution count  #
-	# of each line.                                                    #
-	####################################################################
+####################################################################
+# llvm-cov Statistics for line coverage                            #
+#                                                                  #
+# See the generated .stpcov file for the detailed execution count  #
+# of each line.                                                    #
+####################################################################
 	${CC} ${CFLAGS} -fprofile-arcs -ftest-coverage ${LDFLAGS} $*.c -o $*
 	for KTEST in $$OUTPUT_DIR/*.ktest ; do \
 		( LD_LIBRARY_PATH=${KLEE_HOME}/lib KTEST_FILE=$$KTEST KLEE_REPLAY_TIMEOUT=${DEFAULT_KLEE_REPLAY_TIMEOUT} ${KLEE_REPLAY} $* $$KTEST ) ; \

--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -245,8 +245,8 @@ ${COREUTILS_NOLINK_DIR}:
 	KLEE_COREUTILS_OPTIONS="--search=dfs --max-time=${EXPERIMENT_TIMEOUT} --max-memory=${EXPERIMENT_MEMORY}" SOLVER_FLAGS="-solver-backend=stp" OUTPUT_DIR=$$OUTPUT_DIR BITCODE_DIR=${COREUTILS_NOLINK_DIR} make $*.klee-out
 
 %.klee-out: build
-	# The testing sandbox reconstructed here is from
-	# http://www.doc.ic.ac.uk/~cristic/klee/klee-cu-sandbox.html
+# The testing sandbox reconstructed here is from
+# http://www.doc.ic.ac.uk/~cristic/klee/klee-cu-sandbox.html
 	@echo =================================================================
 	@echo Creating the sandbox ...
 	@echo =================================================================
@@ -294,8 +294,9 @@ ${COREUTILS_NOLINK_DIR}:
 	fi ; \
 	PROGRAM_OPTIONS="$$PROGRAM_OPTIONS -max-fail 1" ; \
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${KLEE_COREUTILS_BASIC_OPTIONS} $$KLEE_COREUTILS_EXTRA_OPTIONS $$SOLVER_FLAGS --environ=${CURDIR}/test.env --run-in=sandbox -output-dir=$$OUTPUT_DIR $$BITCODE_DIR/$*.bc $$PROGRAM_OPTIONS -max-fail 1 ; \
+	${KLEE_STATS} $$OUTPUT_DIR ; \
 	echo -n "$$PROGRAM_OPTIONS" > $$OUTPUT_DIR/ProgramOptions.txt ; \
-	# Delete the sandbox
+# Delete the sandbox
 	rm -rf sandbox sandbox.temps
 	# Generate line coverage information
 	if [ "${ENABLE_COVERAGE}" != "OFF" ] ; then \
@@ -351,7 +352,7 @@ ${EXPERIMENT_CSV}.only:
 				printf "$$program$$ext," >> $@; \
 				cat $$program$$ext/ProgramOptions.txt >> $@; \
 				printf ", " >> $@; \
-				klee-stats $$program$$ext | sed '4q;d' | cut -d '|' -f4  | tr -d '\n' >> $@; \
+				${KLEE_STATS} $$program$$ext | sed '4q;d' | cut -d '|' -f4  | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
 				grep "Elapsed:" ${CURDIR}/$$program$$ext/info | cut -d' ' -f2 |  sed 's/:/ /g;' | awk '{print $$3" "$$2" "$$1}' | awk '{print $$1+$$2*60+$$3*3600}' | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
@@ -375,9 +376,9 @@ ${EXPERIMENT_CSV}.only:
 				printf ", " >> $@; \
 				grep "average instructions of subsumed paths" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
-				klee-stats $$program$$ext | sed '4q;d' | cut -d '|' -f5 | tr -d '\n' >> $@; \
+				${KLEE_STATS} $$program$$ext | sed '4q;d' | cut -d '|' -f5 | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
-				klee-stats $$program$$ext | sed '4q;d' | cut -d '|' -f6 | tr -d '\n' >> $@; \
+				${KLEE_STATS} $$program$$ext | sed '4q;d' | cut -d '|' -f6 | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
 				if [ "${ENABLE_COVERAGE}" != "OFF" ] ; then \
 					if [ -e $$program$$ext/LcovLog.txt ]; then \

--- a/scalability/Makefile
+++ b/scalability/Makefile
@@ -200,6 +200,7 @@ clean: standard-clean
 		KLEE_OPTIONS="${KLEE_DEFAULT_OPTIONS}" ; \
 	fi ; \
 	LD_LIBRARY_PATH=${EXTRA_LD_LIBRARY_PATH} time ${KLEE} ${EXTRA_OPTIONS} $$KLEE_OPTIONS $$KLEE_MORE_OPTIONS $$SOLVER_FLAGS -output-dir=$$OUTPUT_DIR ${CURDIR}/$*.bc $$KLEE_PROGRAM_OPTIONS ; \
+	${KLEE_STATS} $$OUTPUT_DIR ; \
 	echo -n "$$KLEE_PROGRAM_OPTIONS" > $$OUTPUT_DIR/ProgramOptions.txt ; \
 	rm -f $*.bc; \
 	if [ -e $$OUTPUT_DIR/tree.dot ]; then \
@@ -208,7 +209,7 @@ clean: standard-clean
 			echo WARNING: Timed out creating .svg file ; \
 		fi ; \
 	fi
-	# Generate line coverage information
+# Generate line coverage information
 	if [ "${ENABLE_COVERAGE}" != "OFF" ] ; then \
 		${CURDIR}/../utils/scalabilitycov.sh "$*" "$$OUTPUT_DIR" ${SCALABILITY_COV_MAX_TIME} ; \
 	fi
@@ -250,7 +251,7 @@ ${EXPERIMENT_CSV}: core-experiment
 				printf "$$program$$ext," >> $@; \
 				cat $$program$$ext/ProgramOptions.txt >> $@ ; \
 				printf ", " >> $@; \
-				klee-stats $$program$$ext | sed '4q;d' | cut -d '|' -f4  | tr -d '\n' >> $@; \
+				${KLEE_STATS} $$program$$ext | sed '4q;d' | cut -d '|' -f4  | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
 				grep "Elapsed:" ${CURDIR}/$$program$$ext/info | cut -d' ' -f2 |  sed 's/:/ /g;' | awk '{print $$3" "$$2" "$$1}' | awk '{print $$1+$$2*60+$$3*3600}' | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
@@ -274,9 +275,9 @@ ${EXPERIMENT_CSV}: core-experiment
 				printf ", " >> $@; \
 				grep "average instructions of subsumed paths" ${CURDIR}/$$program$$ext/info | sed -E  's/(.*)=(.*)/\2/' | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
-				klee-stats $$program$$ext | sed '4q;d' | cut -d '|' -f5 | tr -d '\n' >> $@; \
+				${KLEE_STATS} $$program$$ext | sed '4q;d' | cut -d '|' -f5 | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
-				klee-stats $$program$$ext | sed '4q;d' | cut -d '|' -f6 | tr -d '\n' >> $@; \
+				${KLEE_STATS} $$program$$ext | sed '4q;d' | cut -d '|' -f6 | tr -d '\n' >> $@; \
 				printf ", " >> $@; \
 				if [ "${ENABLE_COVERAGE}" != "OFF" ] ; then \
 					grep '^[[:space:]]*[[:digit:]]\+' $$program$$ext/$$program.cov |wc -l |tr -d '\n' >> $@; \


### PR DESCRIPTION
Also corrected comments indentation in `Makefile`s. In a `Makefile`, comments should not be indented.