### PR TITLE
Removed -interpolation-stat options

### DIFF
--- a/abstract/Makefile
+++ b/abstract/Makefile
@@ -4,7 +4,7 @@
 
 # We enable execution tree (tree.dot) output as the examples
 # in this directory are small.
-EXTRA_OPTIONS=-output-tree -interpolation-stat -write-pcs -use-query-log=all:pc,all:smt2
+EXTRA_OPTIONS=-output-tree -write-pcs -use-query-log=all:pc,all:smt2
 
 TARGETS=$(patsubst %.c,%.tx,$(wildcard *.c))
 

--- a/basic/Makefile
+++ b/basic/Makefile
@@ -4,7 +4,7 @@
 
 # We enable execution tree (tree.dot) output as the examples
 # in this directory are small.
-EXTRA_OPTIONS=-output-tree -interpolation-stat -write-pcs -use-query-log=all:pc,all:smt2
+EXTRA_OPTIONS=-output-tree -write-pcs -use-query-log=all:pc,all:smt2
 
 # We silence int to pointer conversion warning
 EXTRA_CFLAGS=-Wno-int-conversion

--- a/binary-chop/Makefile
+++ b/binary-chop/Makefile
@@ -4,7 +4,7 @@
 
 # We enable execution tree (tree.dot) output as the examples
 # in this directory are small.
-EXTRA_OPTIONS=-output-tree -interpolation-stat -write-pcs -use-query-log=all:pc,all:smt2 -special-function-bound-interpolation  -no-bound-check #-debug-subsumption=1 #-exit-on-error  
+EXTRA_OPTIONS=-output-tree -write-pcs -use-query-log=all:pc,all:smt2 -special-function-bound-interpolation  -no-bound-check #-debug-subsumption=1 #-exit-on-error  
 
 # We silence int to pointer conversion warning
 EXTRA_CFLAGS=-Wno-int-conversion

--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -196,7 +196,7 @@ ${COREUTILS_NOLINK_DIR}:
 	if [ -z "$$KLEE_COREUTILS_OPTIONS" ] ; then \
 		KLEE_COREUTILS_OPTIONS="${KLEE_COREUTILS_DEFAULT_OPTIONS}" ; \
 	fi ; \
-	KLEE_COREUTILS_OPTIONS="$$KLEE_COREUTILS_OPTIONS --libc=uclibc --max-time=${EXPERIMENT_TIMEOUT} --max-memory=${EXPERIMENT_MEMORY} -interpolation-stat" SOLVER_FLAGS="-solver-backend=z3" OUTPUT_DIR=$$OUTPUT_DIR BITCODE_DIR=${COREUTILS_LLVM_DIR}/src make $*.klee-out
+	KLEE_COREUTILS_OPTIONS="$$KLEE_COREUTILS_OPTIONS --libc=uclibc --max-time=${EXPERIMENT_TIMEOUT} --max-memory=${EXPERIMENT_MEMORY}" SOLVER_FLAGS="-solver-backend=z3" OUTPUT_DIR=$$OUTPUT_DIR BITCODE_DIR=${COREUTILS_LLVM_DIR}/src make $*.klee-out
 
 %.klee:
 	if [ -z "$$OUTPUT_DIR" ] ; then \
@@ -224,7 +224,7 @@ ${COREUTILS_NOLINK_DIR}:
 	if [ -z "$$KLEE_COREUTILS_OPTIONS" ] ; then \
 		KLEE_COREUTILS_OPTIONS="${KLEE_COREUTILS_DEFAULT_OPTIONS}" ; \
 	fi ; \
-	KLEE_COREUTILS_OPTIONS="--search=dfs --max-time=${EXPERIMENT_TIMEOUT} --max-memory=${EXPERIMENT_MEMORY}" SOLVER_FLAGS="-solver-backend=z3 -interpolation-stat" OUTPUT_DIR=$$OUTPUT_DIR BITCODE_DIR=${COREUTILS_NOLINK_DIR} make $*.klee-out
+	KLEE_COREUTILS_OPTIONS="--search=dfs --max-time=${EXPERIMENT_TIMEOUT} --max-memory=${EXPERIMENT_MEMORY}" SOLVER_FLAGS="-solver-backend=z3" OUTPUT_DIR=$$OUTPUT_DIR BITCODE_DIR=${COREUTILS_NOLINK_DIR} make $*.klee-out
 
 %.klee-nolink:
 	if [ -z "$$OUTPUT_DIR" ] ; then \

--- a/join/Makefile
+++ b/join/Makefile
@@ -4,7 +4,7 @@
 
 # We enable execution tree (tree.dot) output as the examples
 # in this directory are small.
-EXTRA_OPTIONS=-output-tree -interpolation-stat -write-pcs -use-query-log=all:pc,all:smt2 -clpr-log
+EXTRA_OPTIONS=-output-tree -write-pcs -use-query-log=all:pc,all:smt2 -clpr-log
 
 # This is for the options passed onto the tested program, e.g.,
 # --sym-arg

--- a/join/mod_eq.c
+++ b/join/mod_eq.c
@@ -5,7 +5,7 @@
  * 
  * make clean
  * clang -emit-llvm -g -c mod_eq.c
- * time /home/felicia/git/tracerx/klee/Release+Asserts/bin/klee -max-time=10 -output-tree -interpolation-stat -write-pcs -use-query-log=all:pc,all:smt2 -allow-external-sym-calls -search=dfs -select-solver=stp -output-dir=mod_eq.stpklee mod_eq.bc -max-fail 1
+ * time /home/felicia/git/tracerx/klee/Release+Asserts/bin/klee -max-time=10 -output-tree -write-pcs -use-query-log=all:pc,all:smt2 -allow-external-sym-calls -search=dfs -select-solver=stp -output-dir=mod_eq.stpklee mod_eq.bc -max-fail 1
  */
 
 #include <klee/klee.h>

--- a/scalability/Makefile
+++ b/scalability/Makefile
@@ -3,7 +3,7 @@
 # Copyright 2016, 2017 National University of Singapore
 
 # This is for extra KLEE options
-EXTRA_OPTIONS=-interpolation-stat
+EXTRA_OPTIONS=
 
 # This is for the options passed onto the tested program, e.g.,
 # --sym-arg
@@ -88,11 +88,11 @@ clean: standard-clean
 
 .bc.tr0:
 	rm -rf $@ klee-*
-	time ${KLEE} -solver-backend=z3 --max-time=120 -interpolation-stat -libc=uclibc --posix-runtime -only-output-states-covering-new -allow-external-sym-calls -output-tree $< --sym-arg 1 --sym-arg 1 --sym-stdin 2000 --max-fail 1
+	time ${KLEE} -solver-backend=z3 --max-time=120 -libc=uclibc --posix-runtime -only-output-states-covering-new -allow-external-sym-calls -output-tree $< --sym-arg 1 --sym-arg 1 --sym-stdin 2000 --max-fail 1
 	rm -rf klee-*
-	time ${KLEE} -solver-backend=z3 --max-time=120 -interpolation-stat -libc=uclibc --posix-runtime -only-output-states-covering-new -allow-external-sym-calls $< --sym-arg 2 --sym-arg 2 --sym-stdin 2000 --max-fail 1
+	time ${KLEE} -solver-backend=z3 --max-time=120 -libc=uclibc --posix-runtime -only-output-states-covering-new -allow-external-sym-calls $< --sym-arg 2 --sym-arg 2 --sym-stdin 2000 --max-fail 1
 	rm -rf klee-*
-	time ${KLEE} -solver-backend=z3 --max-time=120 -interpolation-stat -libc=uclibc --posix-runtime -only-output-states-covering-new -allow-external-sym-calls $< --sym-arg 3 --sym-arg 3 --sym-stdin 2000 --max-fail 1
+	time ${KLEE} -solver-backend=z3 --max-time=120 -libc=uclibc --posix-runtime -only-output-states-covering-new -allow-external-sym-calls $< --sym-arg 3 --sym-arg 3 --sym-stdin 2000 --max-fail 1
 	touch $@
 
 %.klee1 : 

--- a/scalability/tr_nosyscall.c
+++ b/scalability/tr_nosyscall.c
@@ -6,7 +6,7 @@
       s: squeeze multiple output characters of string2 into one character
 
 clang -emit-llvm -c -g tr_nosyscall.c -o tr_nosyscall.bc
-time ~/git/tracerx/klee/Release+Asserts/bin/klee -libc=uclibc -interpolation-stat --posix-runtime -only-output-states-covering-new -allow-external-sym-calls ./tr_nosyscall.bc --sym-arg 1 --sym-arg 1 --sym-arg 1 --sym-files 2 2000 --max-fail 1 
+time ~/git/tracerx/klee/Release+Asserts/bin/klee -libc=uclibc --posix-runtime -only-output-states-covering-new -allow-external-sym-calls ./tr_nosyscall.bc --sym-arg 1 --sym-arg 1 --sym-arg 1 --sym-files 2 2000 --max-fail 1 
 
 clang -emit-llvm -c -g tr_nosyscall.c -o tr_nosyscall.bc
 time ~/git/original/klee/Release+Asserts/bin/klee -libc=uclibc --posix-runtime -only-output-states-covering-new -allow-external-sym-calls ./tr_nosyscall.bc --sym-arg 1 --sym-arg 1 --sym-arg 1 --sym-files 2 2000 --max-fail 1 


### PR DESCRIPTION
In conjunction to tracer-x/klee#257, removing all `-interpolation-stats` occurrences.