### PR TITLE
Variants of former pointer_wp.c to test -special-function-bound-interpolation

### DIFF
--- a/basic/error.dat
+++ b/basic/error.dat
@@ -48,6 +48,8 @@ pointer_struct5.c	0
 pointer_struct6.c	0
 pointer_struct7.c	0
 pointer_symbolic.c	1
+pointer_wp1.c		0
+pointer_wp2.c		1
 polynomial.c		0
 recursion1.c		0
 recursion2.c		0

--- a/basic/error.dat
+++ b/basic/error.dat
@@ -36,7 +36,6 @@ missing_error.c		1
 openssl.c		2
 openssl_partial_fix.c	1
 pointer_alloc.c		1
-pointer_wp.c		0
 pointer_loop.c		1
 pointer_recursive.c	0
 pointer_iterative.c	1
@@ -50,6 +49,7 @@ pointer_struct7.c	0
 pointer_symbolic.c	1
 pointer_wp1.c		0
 pointer_wp2.c		1
+pointer_wp3.c		1
 polynomial.c		0
 recursion1.c		0
 recursion2.c		0

--- a/basic/pointer_wp1.c
+++ b/basic/pointer_wp1.c
@@ -2,7 +2,7 @@
  * Copyright 2016, 2017 National University of Singapore
  *
  * This program is for testing memory bounds check interpolation: it
- * should have interpolations not just at/near the end of the traces.
+ * should have subsumptions not just at/near the end of the traces.
  */
 #ifdef LLBMC
 #include <llbmc.h>

--- a/basic/pointer_wp2.c
+++ b/basic/pointer_wp2.c
@@ -1,8 +1,12 @@
 /*
  * Copyright 2016, 2017 National University of Singapore
  *
- * This program is for testing memory bounds check interpolation: it
- * should have subsumptions not just at/near the end of the traces.
+ * This program is for testing memory bounds check interpolation: It
+ * should discover an error because some memory bounds are not
+ * satisfied in subsumption check.
+ * 
+ * The error report should disappear with the use of the option
+ * -special-function-bound-interpolation.
  */
 #ifdef LLBMC
 #include <llbmc.h>

--- a/basic/pointer_wp2.c
+++ b/basic/pointer_wp2.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2016, 2017 National University of Singapore
+ *
+ * This program is for testing memory bounds check interpolation: it
+ * should have subsumptions not just at/near the end of the traces.
+ */
+#ifdef LLBMC
+#include <llbmc.h>
+#else
+#include <klee/klee.h>
+#endif
+
+int main(int argc, char **argv)
+{
+  char s[10];
+  int p1, p2, p3;
+  char *p;
+
+#ifdef LLBMC
+  p1 = __llbmc_nondef_int();
+  p2 = __llbmc_nondef_int();
+  p3 = __llbmc_nondef_int();
+#else
+  klee_make_symbolic(&p1, sizeof(int), "p1");
+  klee_make_symbolic(&p2, sizeof(int), "p2");
+  klee_make_symbolic(&p3, sizeof(int), "p3");
+#endif
+
+  p = s;
+
+  if (p1) {
+    p += 2;
+  } else {
+    p += 1;
+  }
+  if (p2) {
+    p += 2;
+  } else {
+    p += 1;
+  }
+  if (p3) {
+    p += 2;
+  } else {
+    p += 7;
+  }
+
+  // p should be in s
+  return *p;
+}
+

--- a/basic/pointer_wp3.c
+++ b/basic/pointer_wp3.c
@@ -1,8 +1,9 @@
 /*
  * Copyright 2016, 2017 National University of Singapore
  *
- * This program is for testing memory bounds check interpolation: it
- * should have subsumptions not just at/near the end of the traces.
+ * This program is for testing memory bounds check interpolation.
+ * Tracer-X KLEE should report error either
+ * -special-function-bound-interpolation is used or not.
  */
 #ifdef LLBMC
 #include <llbmc.h>

--- a/basic/pointer_wp3.c
+++ b/basic/pointer_wp3.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright 2016, 2017 National University of Singapore
+ *
+ * This program is for testing memory bounds check interpolation: it
+ * should have subsumptions not just at/near the end of the traces.
+ */
+#ifdef LLBMC
+#include <llbmc.h>
+#else
+#include <klee/klee.h>
+#endif
+
+int tracerx_check(char *p) {
+  return *p;
+}
+
+int main(int argc, char **argv)
+{
+  char s[10];
+  int p1, p2, p3;
+  char *p;
+
+#ifdef LLBMC
+  p1 = __llbmc_nondef_int();
+  p2 = __llbmc_nondef_int();
+  p3 = __llbmc_nondef_int();
+#else
+  klee_make_symbolic(&p1, sizeof(int), "p1");
+  klee_make_symbolic(&p2, sizeof(int), "p2");
+  klee_make_symbolic(&p3, sizeof(int), "p3");
+#endif
+
+  p = s;
+
+  if (p1) {
+    p += 2;
+  } else {
+    p += 1;
+  }
+  if (p2) {
+    p += 2;
+  } else {
+    p += 1;
+  }
+  if (p3) {
+    p += 2;
+  } else {
+    p += 7;
+  }
+
+  // p should be in s
+  return tracerx_check(p);
+}
+

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -33,7 +33,8 @@ memory-access.c		3
 openssl.c		4
 openssl_partial_fix.c	0
 pointer_alloc.c		0
-pointer_wp.c		4
+pointer_wp1.c		4
+pointer_wp2.c		4
 pointer_loop.c		6
 pointer_recursive.c	4
 pointer_iterative.c	1

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -33,8 +33,6 @@ memory-access.c		3
 openssl.c		4
 openssl_partial_fix.c	0
 pointer_alloc.c		0
-pointer_wp1.c		4
-pointer_wp2.c		4
 pointer_loop.c		6
 pointer_recursive.c	4
 pointer_iterative.c	1
@@ -44,6 +42,9 @@ pointer_struct3.c	0
 pointer_struct4.c	0
 pointer_struct6.c	0
 pointer_symbolic.c	0
+pointer_wp1.c		4
+pointer_wp2.c		4
+pointer_wp3.c		4
 polynomial.c		0
 recursion1.c		0
 recursion2.c		28


### PR DESCRIPTION
This adds two files: `pointer_wp2.c` to test non-subsumption due to memory bound interpolation, and `pointer_wp3.c` to test for `-special-function-bound-interpolation` still generating effective bound interpolation with using `tracerx_check`. The old `pointer_wp.c` has been renamed to `pointer_wp1.c`.
