### PR TITLE
Update for subsumption fix

### DIFF
--- a/basic/constant_dep.c
+++ b/basic/constant_dep.c
@@ -1,0 +1,57 @@
+/*
+ * Simple example to exhibit a problem previously occurring due the
+ * invalid dependency between return value of main (a constant 0) and
+ * the constant 0 used in the comparison in the second if
+ * conditional. Since the proof was valid, the constant 0 was
+ * considered to be part of the interpolant, and hence, the location
+ * used to store the constant gets included in the
+ * interpolant. Running Tracer-X KLEE with -debug-subsumption=3
+ * exhibits this issue. 
+ *
+ * Copyright 2017 National University of Singapore
+ */
+
+#ifdef LLBMC
+#include <llbmc.h>
+#else
+#include <klee/klee.h>
+#endif
+
+char _bound[7];
+char *wcet;
+
+char tracerx_check(char *p) {
+  printf("Timing of Path:%d\n",(int)p-(int)(&(_bound)));
+  return *p;
+}
+
+int main(int argc, char **argv)
+{
+
+  int p1, p2;
+  wcet = _bound;
+
+#ifdef LLBMC
+  p1 = __llbmc_nondef_int();
+  p2 = __llbmc_nondef_int();
+#else
+  klee_make_symbolic(&p1, sizeof(int), "p1");
+  klee_make_symbolic(&p2, sizeof(int), "p2");
+#endif
+  
+  if (p1 > 0) {
+    wcet += 1;
+    p2 = 1;
+  } else {
+    wcet += 2;
+    p2 = 2;
+  }
+  if (p2 > 0) {
+    wcet += 3;
+  } else {
+    wcet += 4;
+  }
+
+  tracerx_check(wcet);
+}
+

--- a/basic/error.dat
+++ b/basic/error.dat
@@ -21,6 +21,7 @@ arraysimple5.c		0
 arraysimple6.c		0
 branch.c		0
 bubble_assert.c		0
+constant_dep.c		0
 double-free.c		1
 even.c			0
 instCountTest		0

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -17,7 +17,7 @@ arraysimple1.c		0
 arraysimple2.c		0
 arraysimple3.c		0
 arraysimple4.c		2
-arraysimple5.c		11
+arraysimple5.c		17
 branch.c		0
 bubble_assert.c		6
 double-free.c		0
@@ -51,11 +51,11 @@ pointer_wp5.c		78
 polynomial.c		0
 recursion1.c		0
 recursion2.c		28
-regexp_iterative.c	166
-regexp_mark.c		26
-regexp_nonrecursive1.c	4
+regexp_iterative.c	174
+regexp_mark.c		14
+regexp_nonrecursive1.c	2
 regexp_nonrecursive3.c	3
-regexp_small.c		8
+regexp_small.c		6
 regexp_tiny.c		2
 sp.c			0
 testmem.c		23

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -20,6 +20,7 @@ arraysimple4.c		2
 arraysimple5.c		17
 branch.c		0
 bubble_assert.c		6
+constant_dep.c		0
 double-free.c		0
 even.c			0
 instCountTest		0


### PR DESCRIPTION
Update to synchronize the subsumption/error counts with tracer-x/klee#268.