### PR TITLE
Added basic/switch.c

### DIFF
--- a/basic/error.dat
+++ b/basic/error.dat
@@ -69,6 +69,7 @@ regexp_small.c		2
 regexp_tiny.c		1
 rutledge.c		1
 sp.c			0
+switch.c		1
 testmem.c		1
 use_after_free.c	1
 validation.c		2

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -62,6 +62,7 @@ regexp_nonrecursive3.c	3
 regexp_small.c		6
 regexp_tiny.c		2
 sp.c			2
+switch.c		0
 testmem.c		23
 use_after_free.c	0
 validation.c		18

--- a/basic/switch.c
+++ b/basic/switch.c
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017 National University of Singapore
+ *
+ * In some versions of Tracer-X, running on this example results in
+ * over-subsumption, with depth-first search.
+ */
+
+#ifdef LLBMC
+#include <llbmc.h>
+#else
+#include <klee/klee.h>
+#include <assert.h>
+#endif
+
+int main() {
+  char c, d, e;
+  int flag = 0;
+  int x = 0;
+  
+#ifdef LLBMC
+  d = __llbmc_nondef_char();
+  e = __llbmc_nondef_char();
+#else
+  klee_make_symbolic(&d, sizeof(d), "d");
+  klee_make_symbolic(&e, sizeof(e), "e");
+#endif
+
+  if (d) {
+    c = 'B';
+  } else {
+    c = 'A';
+  }
+
+  if (e) {
+    x++;
+  } else {
+    x+=2;
+  }
+
+  switch (c) {
+  case 'A': {
+    x++;
+    break;
+  }
+  case 'B': {
+    flag = 1;
+    break;
+  }
+  default:
+    break;
+  }
+  
+  if (flag)
+    assert(0);
+
+  return x;
+} 


### PR DESCRIPTION
This example demontrates an over-subsumption problem in Tracer-X. Also added its entries in basic/subsumption.dat and basic/error.dat.