### PR TITLE
Added basic/veritesting_plus_small.c

### DIFF
--- a/basic/error.dat
+++ b/basic/error.dat
@@ -76,3 +76,4 @@ switch.c		1
 testmem.c		1
 use_after_free.c	1
 validation.c		2
+veritesting_plus_small.c	1

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -30,7 +30,7 @@ interproc.c		4
 local.c			4
 loop_safe1.c		0
 loop_safe2.c		9
-loop_unsafe1.c		5
+loop_unsafe1.c		6
 malloc1.c		0
 malloc3.c		14
 masked_error1.c		0
@@ -48,7 +48,7 @@ pointer_struct1.c	0
 pointer_struct2.c	0
 pointer_struct3.c	2
 pointer_struct4.c	0
-pointer_struct6.c	109
+pointer_struct6.c	127
 pointer_symbolic.c	0
 pointer_wp1.c		4
 pointer_wp2.c		2
@@ -58,8 +58,8 @@ pointer_wp5.c		78
 polynomial.c		0
 recursion1.c		0
 recursion2.c		28
-regexp_iterative.c	150
-regexp_mark.c		16
+regexp_iterative.c	166
+regexp_mark.c		15
 regexp_nonrecursive1.c	4
 regexp_nonrecursive3.c	3
 regexp_small.c		6
@@ -69,4 +69,4 @@ switch.c		0
 testmem.c		23
 use_after_free.c	0
 validation.c		18
-veritesting_plus_small.c	34
+veritesting_plus_small.c	56

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -69,3 +69,4 @@ switch.c		0
 testmem.c		23
 use_after_free.c	0
 validation.c		18
+veritesting_plus_small.c	34

--- a/basic/veritesting_plus_small.c
+++ b/basic/veritesting_plus_small.c
@@ -1,0 +1,54 @@
+/*
+ * From Avgerinos et al.: Enhancing Symbolic Execution with
+ * Veritesting, with modifications proposed by Chu Duc Hiep.
+ *
+ * In this example, Tracer-X KLEE over-subsumes and not able to
+ * demonstrate the assertion violation, which can be demonstrated by
+ * LLBMC. In this version, the variable start is also replaced with 0,
+ * and the loop iterations reduced to 9.
+ *
+ * To run with LLBMC, compile with -DLLBMC, and execute LLBMC with the
+ * options --ignore-missing-function-bodies -function-name=main
+ * -no-overflow-checks -max-loop-iterations=0
+ * -max-function-call-depth=0 -counterexample.
+ *
+ * Portions copyright 2017 National University of Singapore
+ */
+#ifdef LLBMC
+#include <llbmc.h>
+#else
+#include <klee/klee.h>
+#include <assert.h>
+#endif
+
+int main(int argc, char **argv) {
+  int counter;
+  char input[9];
+
+#ifdef LLBMC
+  for (int i = 0; i < 9; ++i) {
+    input[i] = __llbmc_nondef_int();
+  }
+#else
+  klee_make_symbolic(input, 9 * sizeof(char), "input");
+#endif
+
+  counter = 0;
+
+  for (int i = 0; i < 9; i++) {
+    if (input[i] == 'B') {
+      counter++;
+    } else {
+      counter += i;
+    }
+  }
+
+// 37 is the maximum value for counter
+#ifdef LLBMC
+  __llbmc_assert(counter != 37);
+#else
+  klee_assert(counter != 37);
+#endif
+
+  return 0;
+}


### PR DESCRIPTION
@rasoolmaghareh This is the smaller example that exhibits tracer-x/klee#219. This PR is not yet ready to be merged as subsumption counts to be recorded in `basic/subsumption.dat` may differ after the fix to Tracer-X KLEE.