### PR TITLE
Corrected subsumption count for pointer_struct6.c

### DIFF
--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -48,7 +48,7 @@ pointer_struct1.c	0
 pointer_struct2.c	0
 pointer_struct3.c	2
 pointer_struct4.c	0
-pointer_struct6.c	127
+pointer_struct6.c	151
 pointer_symbolic.c	0
 pointer_wp1.c		4
 pointer_wp2.c		2


### PR DESCRIPTION
In basic/subsumption.dat, in conjunction with tracer-x/klee#304.