### PR TITLE
Added assume.c

### DIFF
--- a/basic/assume.c
+++ b/basic/assume.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright 2017 National University of Singapore 
+ *
+ * This example showed missed subsumption due to the error in the
+ * construction of existentially-quantified formula for Z3.
+ */
+
+#include <klee/klee.h>
+#include <assert.h>
+
+int inc(int x) { 
+  return x + 1;
+} 
+
+int main() {
+  char p1, p2;
+  int x;
+  
+  klee_make_symbolic(&x, sizeof(x), "x");
+  klee_make_symbolic(&p1, sizeof(p1), "p1");
+  klee_make_symbolic(&p2, sizeof(p2), "p2");
+
+  /* We gain subsumption when this is replaced with an assignment of x
+     with 0. */
+  klee_assume(x == 0);
+  
+  if (p1) {
+    x++;
+  } else {
+    x = inc(x);
+  }
+
+  if (p2) {
+    x++;
+  } else {
+    x = inc(x);
+  }
+
+  klee_assert(x > 0);
+  
+  return 0;
+} 

--- a/basic/error.dat
+++ b/basic/error.dat
@@ -19,6 +19,7 @@ arraysimple3.c		0
 arraysimple4.c		0
 arraysimple5.c		0
 arraysimple6.c		0
+assume.c		0
 branch.c		0
 bubble_assert.c		0
 constant_dep.c		0

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -50,7 +50,7 @@ pointer_struct2.c	0
 pointer_struct3.c	2
 pointer_struct4.c	0
 pointer_struct6.c	151
-pointer_symbolic.c	0
+pointer_symbolic.c	2
 pointer_wp1.c		4
 pointer_wp2.c		2
 pointer_wp3.c		2

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -18,6 +18,7 @@ arraysimple2.c		0
 arraysimple3.c		0
 arraysimple4.c		2
 arraysimple5.c		14
+assume.c		2
 branch.c		0
 bubble_assert.c		6
 constant_dep.c		0


### PR DESCRIPTION
`assume.c` is the test case for issue tracer-x/klee#194. This PR also updates the subsumption count for `pointer_symbolic.c` in `basic/subsumption.dat`.