### PR TITLE
Updated table generation in the [scalability,coreutils]/Makefile

### DIFF
--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -412,9 +412,9 @@ ${EXPERIMENT_CSV}.only:
 	done
 	rm -f small-$@
 	if [ "${ENABLE_COVERAGE}" != "OFF" ] ; then \
-		cut --delimiter=, --fields="1,3,5-10,15-18,25-" $@ > small-$@ ; \
+		cut --delimiter=, --fields="1,3,5-10,15-18" $@ > small-$@ ; \
 	else \
-		cut --delimiter=, --fields="1,3,5-10,15-17,24-" $@ > small-$@ ; \
+		cut --delimiter=, --fields="1,3,5-10,15,16" $@ > small-$@ ; \
 	fi
 
 # This target is used for collecting data from experimental results

--- a/scalability/Makefile
+++ b/scalability/Makefile
@@ -311,9 +311,9 @@ ${EXPERIMENT_CSV}: core-experiment
 	done
 	rm -f small-$@
 	if [ "${ENABLE_COVERAGE}" != "OFF" ] ; then \
-		cut --delimiter=, --fields="1,3,5-10,15-18,25-" $@ > small-$@ ; \
+		cut --delimiter=, --fields="1,3,5-10,15-18" $@ > small-$@ ; \
 	else \
-		cut --delimiter=, --fields="1,3,5-10,15-17,24-" $@ > small-$@ ; \
+		cut --delimiter=, --fields="1,3,5-10,15,16" $@ > small-$@ ; \
 	fi
 
 # This target is used for collecting data from LLBMC experiment into CSV file.


### PR DESCRIPTION
 Reduce the number of columns in the `small-experiment.csv` (the generated experimental table with less columns).