### PR TITLE
Corrected subsumption counts in basic/subsumption.dat

### DIFF
--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -31,7 +31,7 @@ instCountTest		0
 interproc.c		4
 local.c			4
 loop_safe1.c		0
-loop_safe2.c		9
+loop_safe2.c		0
 loop_unsafe1.c		6
 malloc1.c		0
 malloc3.c		14
@@ -58,12 +58,12 @@ pointer_wp3.c		2
 pointer_wp4.c		8
 pointer_wp5.c		78
 polynomial.c		0
-queens.c		50
+queens.c		49
 recursion1.c		0
 recursion2.c		28
-regexp_iterative.c	166
-regexp_mark.c		15
-regexp_nonrecursive1.c	4
+regexp_iterative.c	151
+regexp_mark.c		12
+regexp_nonrecursive1.c	2
 regexp_nonrecursive3.c	3
 regexp_small.c		6
 regexp_tiny.c		2


### PR DESCRIPTION
In accordance to the recent merge tracer-x/klee#320.