### PR TITLE
Disabled overflow, shift, and disjoint memcpy checks in Makefile.comm…

### DIFF
--- a/Makefile.common.in
+++ b/Makefile.common.in
@@ -70,7 +70,21 @@ LLBMC_DEFAULT_TIMEOUT=3600
 # not complete.
 #
 # Then you can try to increase the values.
-LLBMC_DEFAULT_OPTIONS=--ignore-missing-function-bodies -function-name=main --no-max-loop-iterations-checks --no-max-function-call-depth-checks -max-loop-iterations=20 -max-function-call-depth=10 --no-overflow-checks
+#
+# The options -no-overflow-checks -no-shift-checks
+# -no-memcpy-disjoint-checks are for fair(er) comparison since KLEE
+# does not do these checks (overflow check has to be enabled in KLEE
+# by a special instrumentation of the bitcode, see:
+# https://klee.github.io/docs/options/#klee-usage
+LLBMC_DEFAULT_OPTIONS=--no-overflow-checks \
+	--no-shift-checks \
+	--no-memcpy-disjoint-checks \
+	--ignore-missing-function-bodies \
+	-function-name=main \
+	--no-max-loop-iterations-checks \
+	--no-max-function-call-depth-checks \
+	-max-loop-iterations=20 \
+	-max-function-call-depth=10
 
 CC=@CC@
 AS=${CC} -S

--- a/coreutils/Makefile
+++ b/coreutils/Makefile
@@ -17,7 +17,13 @@ COREUTILS_NOLINK_DIR=${COREUTILS_DIR}/obj-nolink
 COREUTILS_COV_MAX_TIME=
 
 CFLAGS_LLBMC_COREUTILS=-g -I${COREUTILS_LLVM_DIR}/lib -I${COREUTILS_DIR}/src -I${COREUTILS_DIR}/lib
-LLBMC_OPTIONS=--ignore-missing-function-bodies -function-name=main -max-loop-iterations=5 -max-function-call-depth=10
+LLBMC_OPTIONS=--no-overflow-checks \
+	--no-shift-checks \
+	--no-memcpy-disjoint-checks \
+	--ignore-missing-function-bodies \
+	-function-name=main \
+	-max-loop-iterations=5 \
+	-max-function-call-depth=10
 
 BASH=/bin/bash
 

--- a/imagemagick/Makefile
+++ b/imagemagick/Makefile
@@ -28,7 +28,13 @@ IMAGEMAGICK_UTILS=animate \
 IMAGEMAGICK_COV_MAX_TIME=
 
 CFLAGS_LLBMC_IMAGEMAGICK=-g -I${IMAGEMAGICK_LLVM_DIR}/lib -I${IMAGEMAGICK_DIR}/src -I${IMAGEMAGICK_DIR}/lib
-LLBMC_OPTIONS=--ignore-missing-function-bodies -function-name=main -max-loop-iterations=5 -max-function-call-depth=10
+LLBMC_OPTIONS=--no-overflow-checks \
+	--no-shift-checks \
+	--no-memcpy-disjoint-checks \
+	--ignore-missing-function-bodies \
+	--function-name=main \
+	--max-loop-iterations=5 \
+	--max-function-call-depth=10
 
 BASH=/bin/bash
 


### PR DESCRIPTION
…on.in, coreutils/Makefile, and imagemagick/Makefile. For resolving issue #108. 