### PR TITLE
Added malloc4.c

### DIFF
--- a/basic/error.dat
+++ b/basic/error.dat
@@ -38,6 +38,7 @@ loop_unsafe1.c		1
 malloc1.c		1
 malloc2.c		0
 malloc3.c		0
+malloc4.c		0
 masked_error1.c		2
 masked_error2.c		2
 masked_error3.c		2

--- a/basic/malloc3.c
+++ b/basic/malloc3.c
@@ -4,6 +4,12 @@
  * For this example, LLBMC seems to get exponentially slower as MAX
  * is increased.
  *
+ * In this program, there is a loop with a branch within it which has
+ * a nondeterministic condition. There are two different allocations
+ * in both branches, in such a way that each execution path has a
+ * unique sequence of addresses returned by malloc(), and there are
+ * exponential number of such sequences / paths.
+ *
  * Copyright 2017 National University of Singapore
  */
 

--- a/basic/malloc4.c
+++ b/basic/malloc4.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright 2017 National University of Singapore
+ *
+ * Trace-X KLEE and KLEE executes only linear in N number of paths,
+ * and asymptotically faster compared to LLBMC where LLBMC running time
+ * for various N is as follows:
+ *
+ * N=20: 0.332s
+ * N=30: 1.192s
+ * N=40: 3.288s
+ * N=50: 7.544s
+ * N=60: 12.184s
+ * N=70: 22.994s
+ *
+ * Obviously there is an exponential blowup here, without the need to
+ * have exponential number of sequences of allocation addresses, as in
+ * malloc3.c. Here, one can hypothesize that KLEE and Tracer-X KLEE
+ * decide infeasibility of paths early (especially of the if
+ * conditional within the for loop), whereas LLBMC delays this
+ * decision making to the constraint solving stage, hence it has
+ * exponential paths to reason about within the solver.
+ *
+ * Originally by Roland Yap ryap@comp.nus.edu.sg
+ */
+
+#include <stdlib.h>
+#include <stdio.h>
+#ifdef LLBMC
+#include <llbmc.h>
+#else
+#include <assert.h>
+#include <klee/klee.h>
+#endif
+
+#define N 20
+
+int dummy = 1;
+
+int *createvar(int n, int m) {
+  int i, *p;
+
+#ifdef LLBMC
+  __llbmc_assume(m < n);
+#else
+  klee_assume(m < n);
+#endif
+
+  for (i = 0; i < n; i++) {
+    if (i < m)
+      p = &dummy;
+    else {
+      p = (int *)malloc(sizeof(int));
+      *p = 0;
+    }
+  }
+  return p;
+}
+
+int main() {
+  int *v, x;
+  int m;
+  int n = N;
+
+#ifdef LLBMC
+  m = __llbmc_nondef_int();
+#else
+  klee_make_symbolic(&m, sizeof(m), "m");
+#endif
+
+  v = createvar(n, m);
+  return *v;
+}

--- a/basic/subsumption.dat
+++ b/basic/subsumption.dat
@@ -36,6 +36,7 @@ loop_safe2.c		0
 loop_unsafe1.c		6
 malloc1.c		0
 malloc3.c		14
+malloc4.c		0
 masked_error1.c		0
 masked_error2.c		0
 masked_error3.c		0


### PR DESCRIPTION
This is another example that can slow down LLBMC. However, KLEE and Tracer-X KLEE traverses the same paths, and hence Tracer-X KLEE is slower than KLEE for this example. Credit goes to Roland Yap for this example. For this example, one can hypothesize that KLEE and Tracer-X KLEE decide infeasibility of paths early (especially of the if conditional within the for loop), whereas LLBMC delays this decision making to the constraint solving stage, hence it has exponential paths to reason about within the solver.